### PR TITLE
Specify OpenMDAO version 1.7.3 in the automated Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
     fi
   fi
 - pip install coveralls
-- pip install openmdao
+- pip install openmdao==1.7.3
 
 script:
 - if [ "$FORTRAN" ]; then


### PR DESCRIPTION
The build is failing because Travis is installing the latest version of OpenMDAO, which is currently 2.2.1. OpenAeroStruct requires OpenMDAO 1.7.3 or 1.7.4. If there is a way to test both OpenMDAO versions in the automated build, then that would probably be a good idea. At least this way the build ought to complete.

OpenMDAO 1.7.4 only recently became available on PyPi so most people will still be using 1.7.3. Plus, the docs for 1.7.4 aren't currently available on the [openmdao.org/docs](http://openmdao.org/docs/) website, so a casual user won't even know it exists.