### PR TITLE
Sparsified derivative on geo radius comp.

### DIFF
--- a/openaerostruct/geometry/radius_comp.py
+++ b/openaerostruct/geometry/radius_comp.py
@@ -50,12 +50,11 @@ class RadiusComp(ExplicitComponent):
         vectors = mesh[-1, :, :] - mesh[0, :, :]
         chords = np.sqrt(np.sum(vectors**2, axis=1))
         t_c = inputs['t_over_c']
-        mean_chords = 0.5 * chords[:-1] + 0.5 * chords[1:]
 
-        dr_dtoc = mean_chords/2
+        dr_dtoc = 0.25 * (chords[:-1] + chords[1:])
         partials['radius','t_over_c'] = dr_dtoc
 
-        dr_dchords = 0.25*t_c
+        dr_dchords = 0.25 * t_c
         dr = mesh[0, :] - mesh[-1, :]
 
         l = np.sqrt(np.sum(dr**2, axis=1))

--- a/openaerostruct/structures/utils.py
+++ b/openaerostruct/structures/utils.py
@@ -59,4 +59,4 @@ def radii(mesh, t_c=0.15):
     vectors = mesh[-1, :, :] - mesh[0, :, :]
     chords = np.sqrt(np.sum(vectors**2, axis=1))
     mean_chords = 0.5 * chords[:-1] + 0.5 * chords[1:]
-    return t_c * mean_chords / 2.
+    return t_c * mean_chords * 0.5


### PR DESCRIPTION
closes #221

On a large mesh (177x51) for model with just this component:
- Execution time for 10 calls to linearize:  1.0 seconds -> .001 seconds
- Memory footprint during check partials: 240 MB -> 180 MB.