### PR TITLE
Bugfix for most recent matplotlib version

### DIFF
--- a/openaerostruct/utils/plot_wingbox.py
+++ b/openaerostruct/utils/plot_wingbox.py
@@ -64,7 +64,6 @@ class Display(object):
         self.canvas._tkcanvas.pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
         self.ax = plt.subplot2grid((5, 8), (0, 0), rowspan=5,
                                    colspan=4, projection='3d')
-        self.ax.set_aspect('equal')
 
         self.num_iters = 0
         self.show_wing = True


### PR DESCRIPTION
## Purpose
Issue #300 showed a bug with the newest version of matplotlib. This PR resolves that by removing the equal axis call to the 3D plot of `plot_wingbox`. The plotting code still works as intended and appears to have the correct view.

See https://github.com/matplotlib/matplotlib/issues/1077/ for details on why 3D plots can't have equal axes.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
GUI testing only; no CI. Ran locally on newest matplotlib.

## Checklist
_Put an `x` in the boxes that apply._

- [X] I have run unit and regression tests which pass locally with my changes
- [X] I have added new tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation
