### PR TITLE
Bug fix: float division was used instead of integer division

### DIFF
--- a/openaerostruct/geometry/utils.py
+++ b/openaerostruct/geometry/utils.py
@@ -692,13 +692,13 @@ def generate_mesh(input_dict):
             # then stack the two together, but remove the duplicated twist
             # value.
             if num_twist % 2:
-                twist = np.interp(np.linspace(0, 1, (num_twist+1)/2), eta, surf_dict['crm_twist'])
+                twist = np.interp(np.linspace(0, 1, (num_twist+1)//2), eta, surf_dict['crm_twist'])
                 twist = np.hstack((twist[:-1], twist[::-1]))
 
             # If num_twist is even, mirror the twist vector and stack
             # them together
             else:
-                twist = np.interp(np.linspace(0, 1, num_twist/2), eta, surf_dict['crm_twist'])
+                twist = np.interp(np.linspace(0, 1, num_twist//2), eta, surf_dict['crm_twist'])
                 twist = np.hstack((twist, twist[::-1]))
 
         return mesh, twist


### PR DESCRIPTION
## Purpose

Use integer division when appropriate. This solves the following error
that appeared during tests:

    TypeError: object of type <class 'float'> cannot be safely interpreted as an integer

My system details are

    >>> import platform, sys
    >>> info = platform.uname()
    >>> (info.system, info.version), (info.machine, info.processor), sys.version
    (('Linux', '#40~18.04.1-Ubuntu SMP Thu Nov 14 12:06:39 UTC 2019'), ('x86_64', 'x86_64'), '3.6.9     (default, Nov  7 2019, 10:44:02) \n[GCC 8.3.0]')


This was causing 14 tests to fail when running on python 3.6, namely

test_aero_analysis_no_symmetry.py:Test.test
test_aero_analysis_no_symmetry_wavedrag.py:Test.test
test_aero_opt_no_symmetry.py:Test.test
test_aero_opt_wavedrag.py:Test.test
test_geometry_mesh_transformations.py:Test.test_dihedral
test_geometry_mesh_transformations.py:Test.test_rotate
test_geometry_mesh_transformations.py:Test.test_scalex
test_geometry_mesh_transformations.py:Test.test_shearx
test_geometry_mesh_transformations.py:Test.test_sheary
test_geometry_mesh_transformations.py:Test.test_shearz
test_geometry_mesh_transformations.py:Test.test_stretch
test_geometry_mesh_transformations.py:Test.test_sweep
test_geometry_mesh_transformations.py:Test.test_taper
test_v1_aerostruct_opt.py:Test.test

Now they pass.

This PR also adds a newline at the end of file as prescribed by PEP8.

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Testing

Ran testflo locally. Results were 
Passed:  146
Failed:  0
Skipped: 7

Also built successfully on Travis

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
