### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 - export PATH=$HOME/.local/bin:$PATH;
 
 # install openmdao
-- pip install "openmdao[all]<3";
+- pip install "openmdao[dev,doc]<3";
 
 # install openaerostruct itself
 - pip install -e .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: generic
 env:
 - PY=2.7
 - PY=3.6
+- PY=3.7
 
 addons:
   apt:
@@ -19,8 +20,11 @@ addons:
     - openmpi-bin
 
 before_install:
-- if [ "$PY" == "2.7" ];  then wget "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" -O miniconda.sh; fi
-- if [ "$PY" == "3.6" ];  then wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh; fi
+- if [ "$PY" == "2.7" ];  then
+    wget "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" -O miniconda.sh;
+  else
+    wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh;
+  fi
 - chmod +x miniconda.sh;
 - ./miniconda.sh -b  -p /home/travis/miniconda;
 - export PATH=/home/travis/miniconda/bin:$PATH;
@@ -38,14 +42,17 @@ install:
 
 - pip install coverage;
 - pip install coveralls;
-- if [ "$PY" == "3.6" ];  then
-    pip install --user travis-sphinx;
-  fi
 - pip install testflo==1.3.6;
 - export PATH=$HOME/.local/bin:$PATH;
 
-# install openmdao
-- pip install "openmdao[docs]<3";
+# install openmdao and sphinx-travis
+# we only install docs dependencies on py3
+- if [ "$PY" == "3.7" ];  then
+    pip install --user travis-sphinx;
+    pip install "openmdao[docs]<3";
+  else
+    pip install "openmdao<3";
+  fi
 
 # install openaerostruct itself
 - pip install -e .;
@@ -53,12 +60,12 @@ install:
 script:
 - export PYTHONPATH=$PYTHONPATH:$PWD
 - testflo -n 1 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
-- if [ "$PY" == "3.6" ];  then
+- if [ "$PY" == "3.7" ];  then
     travis-sphinx build --source=openaerostruct/docs;
   fi
 
 after_success:
-- if [ "$PY" == "3.6" ];  then
+- if [ "$PY" == "3.7" ];  then
     travis-sphinx deploy;
     coveralls;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
 - pip install coveralls;
 - if [ "$PY" = "3.6" ];  then
     pip install --user travis-sphinx;
+  fi
 - pip install testflo;
 - export PATH=$HOME/.local/bin:$PATH;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ addons:
     - openmpi-bin
 
 before_install:
-- if [ "$PY" = "2.7" ];  then wget "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" -O miniconda.sh; fi
-- if [ "$PY" = "3.6" ];  then wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh; fi
+- if [ "$PY" == "2.7" ];  then wget "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" -O miniconda.sh; fi
+- if [ "$PY" == "3.6" ];  then wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh; fi
 - chmod +x miniconda.sh;
 - ./miniconda.sh -b  -p /home/travis/miniconda;
 - export PATH=/home/travis/miniconda/bin:$PATH;
@@ -38,14 +38,14 @@ install:
 
 - pip install coverage;
 - pip install coveralls;
-- if [ "$PY" = "3.6" ];  then
+- if [ "$PY" == "3.6" ];  then
     pip install --user travis-sphinx;
   fi
 - pip install testflo==1.3.6;
 - export PATH=$HOME/.local/bin:$PATH;
 
 # install openmdao
-- pip install "openmdao[dev,doc]<3";
+- pip install "openmdao[docs]<3";
 
 # install openaerostruct itself
 - pip install -e .;
@@ -53,12 +53,12 @@ install:
 script:
 - export PYTHONPATH=$PYTHONPATH:$PWD
 - testflo -n 1 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
-- if [ "$PY" = "3.6" ];  then
+- if [ "$PY" == "3.6" ];  then
     travis-sphinx build --source=openaerostruct/docs;
   fi
 
 after_success:
-- if [ "$PY" = "3.6" ];  then
+- if [ "$PY" == "3.6" ];  then
     travis-sphinx deploy;
     coveralls;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ install:
 - if [ "$PY" = "3.6" ];  then
     pip install --user travis-sphinx;
   fi
-- pip install testflo;
+- pip install testflo==1.3.6;
 - export PATH=$HOME/.local/bin:$PATH;
 
 # install openmdao
-- pip install "openmdao<3";
+- pip install "openmdao[all]<3";
 
 # install openaerostruct itself
 - pip install -e .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,10 @@ script:
 - testflo -n 1 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
 - if [ "$PY" = "3.6" ];  then
     travis-sphinx build --source=openaerostruct/docs;
+  fi
 
 after_success:
 - if [ "$PY" = "3.6" ];  then
     travis-sphinx deploy;
     coveralls;
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,13 @@ install:
 
 - pip install coverage;
 - pip install coveralls;
-- pip install --user travis-sphinx;
+- if [ "$PY" = "3.6" ];  then
+    pip install --user travis-sphinx;
 - pip install testflo;
 - export PATH=$HOME/.local/bin:$PATH;
 
 # install openmdao
-- pip install openmdao[docs,dev];
+- pip install "openmdao<3";
 
 # install openaerostruct itself
 - pip install -e .;
@@ -51,8 +52,10 @@ install:
 script:
 - export PYTHONPATH=$PYTHONPATH:$PWD
 - testflo -n 1 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
-- travis-sphinx build --source=openaerostruct/docs;
+- if [ "$PY" = "3.6" ];  then
+    travis-sphinx build --source=openaerostruct/docs;
 
 after_success:
-- travis-sphinx deploy;
-- coveralls;
+- if [ "$PY" = "3.6" ];  then
+    travis-sphinx deploy;
+    coveralls;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OpenAeroStruct
 ==============
 
-[![Build Status](https://travis-ci.org/mdolab/OpenAeroStruct.svg?branch=master)](https://travis-ci.org/mdolab/OpenAeroStruct)
+[![Build Status](https://travis-ci.com/mdolab/OpenAeroStruct.svg?branch=master)](https://travis-ci.com/mdolab/OpenAeroStruct)
 [![Coverage Status](https://coveralls.io/repos/github/mdolab/OpenAeroStruct/badge.svg?branch=master)](https://coveralls.io/github/mdolab/OpenAeroStruct?branch=master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/mdolab/OpenAeroStruct.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/mdolab/OpenAeroStruct/context:python)
 


### PR DESCRIPTION
## Purpose
I migrated openAeroStruct from Travis-CI.org to Travis-CI.com today. After that, the build started failing, partly because openMDAO released v3 recently and that broke a bunch of API. I've pinned `openmdao<3` and `testflo==1.3.6` for now. I've also added python 3.7 since that's now available through miniconda.

The tests now pass on travis, although with an openFabrics warning that wasn't there before. Not 100% why that shows up now. Anyhow, this PR should be squashed when merged.

I think the next step would be to actually address those API changes. Then we can finally piggy-back off of openMDAO and ditch py2 also.