### PR TITLE
Update OAS to OM 3.0 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,16 @@ install:
 
 # install openmdao and sphinx-travis
 # we only install docs dependencies on py3
+# install pyoptsparse
+- git clone https://github.com/openmdao/openmdao.git;
+- cd openmdao;
 - if [ "$PY" == "3.7" ];  then
     pip install --user travis-sphinx;
-    pip install "openmdao[docs]";
+    pip install .[docs];
   else
-    pip install "openmdao";
+    pip install .;
   fi
+  - cd ..;
 
 # install openaerostruct itself
 - pip install -e .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ install:
 # we only install docs dependencies on py3
 - if [ "$PY" == "3.7" ];  then
     pip install --user travis-sphinx;
-    pip install "openmdao[docs]<3";
+    pip install "openmdao[docs]";
   else
-    pip install "openmdao<3";
+    pip install "openmdao";
   fi
 
 # install openaerostruct itself

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ install:
 - cd openmdao;
 - if [ "$PY" == "3.7" ];  then
     pip install --user travis-sphinx;
-    pip install .[docs];
+    pip install -e .[docs];
   else
-    pip install .;
+    pip install -e .;
   fi
   - cd ..;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os:
-  - linux
+- linux
 
 language: generic
 
@@ -18,7 +18,7 @@ addons:
     - openmpi-bin
 
 before_install:
-  wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh;
+-  wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh;
 - chmod +x miniconda.sh;
 - ./miniconda.sh -b  -p /home/travis/miniconda;
 - export PATH=/home/travis/miniconda/bin:$PATH;
@@ -44,7 +44,7 @@ install:
 - cd openmdao;
 - pip install --user travis-sphinx;
 - pip install ".[docs]";
-  - cd ..;
+- cd ..;
 
 # install openaerostruct itself
 - pip install -e .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,15 +47,15 @@ install:
 
 # install openmdao and sphinx-travis
 # we only install docs dependencies on py3
-# install pyoptsparse
 - git clone https://github.com/openmdao/openmdao.git;
 - cd openmdao;
 - if [ "$PY" == "3.7" ];  then
     pip install --user travis-sphinx;
-    pip install -e .[docs];
+    pip install ".[docs]";
   else
-    pip install -e .;
+    pip install ".";
   fi
+  
   - cd ..;
 
 # install openaerostruct itself

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ os:
 language: generic
 
 env:
-- PY=2.7
-- PY=3.6
 - PY=3.7
 
 addons:
@@ -20,11 +18,7 @@ addons:
     - openmpi-bin
 
 before_install:
-- if [ "$PY" == "2.7" ];  then
-    wget "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" -O miniconda.sh;
-  else
-    wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh;
-  fi
+  wget "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh;
 - chmod +x miniconda.sh;
 - ./miniconda.sh -b  -p /home/travis/miniconda;
 - export PATH=/home/travis/miniconda/bin:$PATH;
@@ -49,13 +43,8 @@ install:
 # we only install docs dependencies on py3
 - git clone https://github.com/openmdao/openmdao.git;
 - cd openmdao;
-- if [ "$PY" == "3.7" ];  then
-    pip install --user travis-sphinx;
-    pip install ".[docs]";
-  else
-    pip install ".";
-  fi
-  
+- pip install --user travis-sphinx;
+- pip install ".[docs]";
   - cd ..;
 
 # install openaerostruct itself
@@ -64,12 +53,8 @@ install:
 script:
 - export PYTHONPATH=$PYTHONPATH:$PWD
 - testflo -n 1 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
-- if [ "$PY" == "3.7" ];  then
-    travis-sphinx build --source=openaerostruct/docs;
-  fi
+- travis-sphinx build --source=openaerostruct/docs;
 
 after_success:
-- if [ "$PY" == "3.7" ];  then
-    travis-sphinx deploy;
-    coveralls;
-  fi
+- travis-sphinx deploy;
+- coveralls;

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
 - export PATH=$HOME/.local/bin:$PATH;
 
 # install openmdao and sphinx-travis
-# we only install docs dependencies on py3
 - git clone https://github.com/openmdao/openmdao.git;
 - cd openmdao;
 - pip install --user travis-sphinx;

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Shamsheer S. Chauhan and Joaquim R. R. A. Martins, “Low-Fidelity Aerostructura
 
 Version Information
 -------------------
-This version of OpenAeroStruct requires [OpenMDAO](https://github.com/OpenMDAO/openmdao) v2.5+.
+This version of OpenAeroStruct requires [OpenMDAO](https://github.com/OpenMDAO/openmdao) v3.0+ and Python3.
+Python2 is no longer supported.
 If you are looking to use the previous version of OpenAeroStruct which uses OpenMDAO 1.7.4, use OpenAeroStruct v1.0 from [here](https://github.com/mdolab/OpenAeroStruct/releases).
 
 License

--- a/example_deriv_check.py
+++ b/example_deriv_check.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp, view_model
+import openmdao.api as om
 
 from six import iteritems
 from numpy.testing import assert_almost_equal
@@ -36,7 +36,7 @@ class Test(unittest.TestCase):
 
         # Instantiate an OpenMDAO problem and add the component we want to test
         # as asubsystem, giving that component a default lifting surface
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('tube', SectionPropertiesTube(surface=surfaces[0]))
 
         # Set up the problem and ensure it uses complex arrays so we can check

--- a/openaerostruct/aerodynamics/aero_groups.py
+++ b/openaerostruct/aerodynamics/aero_groups.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group, LinearRunOnce
+import openmdao.api as om
 from openaerostruct.aerodynamics.compressible_states import CompressibleVLMStates
 from openaerostruct.aerodynamics.geometry import VLMGeometry
 from openaerostruct.aerodynamics.states import VLMStates
@@ -6,7 +6,7 @@ from openaerostruct.aerodynamics.functionals import VLMFunctionals
 from openaerostruct.functionals.total_aero_performance import TotalAeroPerformance
 
 
-class AeroPoint(Group):
+class AeroPoint(om.Group):
     """
     This group contains all the components needed for a single-point aerodynamic
     analysis. You would have one instance of `AeroPoint` for each flight
@@ -67,7 +67,7 @@ class AeroPoint(Group):
             aero_states = VLMStates(surfaces=surfaces, rotational=rotational)
             prom_in = ['v', 'alpha', 'beta', 'rho']
 
-        aero_states.linear_solver = LinearRunOnce()
+        aero_states.linear_solver = om.LinearRunOnce()
 
         if rotational:
             prom_in.extend(['omega', 'cg'])

--- a/openaerostruct/aerodynamics/coeffs.py
+++ b/openaerostruct/aerodynamics/coeffs.py
@@ -1,9 +1,9 @@
 from __future__ import print_function, division
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class Coeffs(ExplicitComponent):
+class Coeffs(om.ExplicitComponent):
     """ Compute lift and drag coefficients for each individual lifting surface.
 
     Parameters

--- a/openaerostruct/aerodynamics/collocation_points.py
+++ b/openaerostruct/aerodynamics/collocation_points.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class CollocationPoints(ExplicitComponent):
+class CollocationPoints(om.ExplicitComponent):
     """
     Compute the Cartesian locations of the collocation points, the force
     analysis points, and the bound vortex vectors for the VLM analysis.

--- a/openaerostruct/aerodynamics/compressible_states.py
+++ b/openaerostruct/aerodynamics/compressible_states.py
@@ -1,7 +1,7 @@
 """
 Class definition for CompressibleVLMStates.
 """
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 
 from openaerostruct.aerodynamics.get_vectors import GetVectors
 from openaerostruct.aerodynamics.collocation_points import CollocationPoints
@@ -20,7 +20,7 @@ from openaerostruct.aerodynamics.vortex_mesh import VortexMesh
 from openaerostruct.aerodynamics.pg_transform import PGTransform, InversePGTransform
 
 
-class CompressibleVLMStates(Group):
+class CompressibleVLMStates(om.Group):
     """
     Group that contains the states for a compressible aerodynamic analysis.
 
@@ -118,7 +118,7 @@ class CompressibleVLMStates(Group):
              promotes_outputs=['*'])
 
         # In the PG domain, alpha and beta are zero.
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('alpha_pg', val=0., units='deg')
         indep_var_comp.add_output('beta_pg', val=0., units='deg')
         self.add_subsystem('pg_frame', indep_var_comp)

--- a/openaerostruct/aerodynamics/convert_velocity.py
+++ b/openaerostruct/aerodynamics/convert_velocity.py
@@ -2,10 +2,10 @@ from __future__ import print_function
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ConvertVelocity(ExplicitComponent):
+class ConvertVelocity(om.ExplicitComponent):
     """
     Convert the freestream velocity magnitude into a velocity vector at each
     evaluation point. In this case, each of the panels sees the same velocity.

--- a/openaerostruct/aerodynamics/eval_mtx.py
+++ b/openaerostruct/aerodynamics/eval_mtx.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.utils.vector_algebra import add_ones_axis
 from openaerostruct.utils.vector_algebra import compute_dot, compute_dot_deriv
@@ -105,7 +105,7 @@ def _compute_semi_infinite_vortex_deriv(u, r, r_deriv):
     return (num_deriv * den - num * den_deriv) / den ** 2 / 4 / np.pi
 
 
-class EvalVelMtx(ExplicitComponent):
+class EvalVelMtx(om.ExplicitComponent):
     """
     Computes the aerodynamic influence coefficient (AIC) matrix for the VLM
     analysis.

--- a/openaerostruct/aerodynamics/eval_velocities.py
+++ b/openaerostruct/aerodynamics/eval_velocities.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class EvalVelocities(ExplicitComponent):
+class EvalVelocities(om.ExplicitComponent):
     """
     Compute the total velocities at each of the evaluation points for every
     panel in the entire system. This is the sum of the freestream and induced

--- a/openaerostruct/aerodynamics/functionals.py
+++ b/openaerostruct/aerodynamics/functionals.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.aerodynamics.lift_drag import LiftDrag
 from openaerostruct.aerodynamics.coeffs import Coeffs
 from openaerostruct.aerodynamics.total_lift import TotalLift
@@ -8,7 +8,7 @@ from openaerostruct.aerodynamics.wave_drag import WaveDrag
 from openaerostruct.aerodynamics.lift_coeff_2D import LiftCoeff2D
 
 
-class VLMFunctionals(Group):
+class VLMFunctionals(om.Group):
     """
     Group that contains the aerodynamic functionals used to evaluate
     performance. These are not included in the coupled aerostructural group,

--- a/openaerostruct/aerodynamics/geometry.py
+++ b/openaerostruct/aerodynamics/geometry.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
 np.random.seed(314)
 
-class VLMGeometry(ExplicitComponent):
+class VLMGeometry(om.ExplicitComponent):
     """
     Compute various geometric properties for VLM analysis.
     These are used primarily to help compute postprocessing quantities,

--- a/openaerostruct/aerodynamics/get_vectors.py
+++ b/openaerostruct/aerodynamics/get_vectors.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class GetVectors(ExplicitComponent):
+class GetVectors(om.ExplicitComponent):
     """
     Compute the vectors going from the vortex mesh points to the evaluation
     points, where the evluation points are either the colloation points

--- a/openaerostruct/aerodynamics/horseshoe_circulations.py
+++ b/openaerostruct/aerodynamics/horseshoe_circulations.py
@@ -2,10 +2,10 @@ from __future__ import print_function
 import numpy as np
 from scipy.sparse import csc_matrix
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class HorseshoeCirculations(ExplicitComponent):
+class HorseshoeCirculations(om.ExplicitComponent):
     """
     Convert the previously-computed vortex ring circulations into horseshoe
     circulations. Vortex rings and horseshoe vortices produce the same linear

--- a/openaerostruct/aerodynamics/lift_coeff_2D.py
+++ b/openaerostruct/aerodynamics/lift_coeff_2D.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division
 import numpy as np
 from numpy import matlib
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class LiftCoeff2D(ExplicitComponent):
+class LiftCoeff2D(om.ExplicitComponent):
     """
     Calculate 2D lift coefficient distribution based on section forces.
     This is for one given lifting surface. These are the sectional Cls.

--- a/openaerostruct/aerodynamics/lift_drag.py
+++ b/openaerostruct/aerodynamics/lift_drag.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class LiftDrag(ExplicitComponent):
+class LiftDrag(om.ExplicitComponent):
     """
     Calculate total lift and drag in force units based on section forces.
     This is for one given lifting surface.

--- a/openaerostruct/aerodynamics/mesh_point_forces.py
+++ b/openaerostruct/aerodynamics/mesh_point_forces.py
@@ -6,10 +6,10 @@ from __future__ import print_function
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MeshPointForces(ExplicitComponent):
+class MeshPointForces(om.ExplicitComponent):
     """
     Component that simply converts the forces on the panel to an equivalent set of forces at the
     mesh points.

--- a/openaerostruct/aerodynamics/mtx_rhs.py
+++ b/openaerostruct/aerodynamics/mtx_rhs.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class VLMMtxRHSComp(ExplicitComponent):
+class VLMMtxRHSComp(om.ExplicitComponent):
     """
     Compute the total velocities at each of the evaluation points for every
     panel in the entire system. This is the sum of the freestream and induced

--- a/openaerostruct/aerodynamics/panel_forces.py
+++ b/openaerostruct/aerodynamics/panel_forces.py
@@ -1,12 +1,12 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.utils.vector_algebra import compute_cross, compute_cross_deriv1, compute_cross_deriv2
 
 
-class PanelForces(ExplicitComponent):
+class PanelForces(om.ExplicitComponent):
     """
     Compute the panel forces acting on all surfaces in the system.
 

--- a/openaerostruct/aerodynamics/panel_forces_surf.py
+++ b/openaerostruct/aerodynamics/panel_forces_surf.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class PanelForcesSurf(ExplicitComponent):
+class PanelForcesSurf(om.ExplicitComponent):
     """
     Take in the computed panel forces and convert them to sectional forces
     for each surface. Basically just takes the long array that has info

--- a/openaerostruct/aerodynamics/pg_scale.py
+++ b/openaerostruct/aerodynamics/pg_scale.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ScaleToPrandtlGlauert(ExplicitComponent):
+class ScaleToPrandtlGlauert(om.ExplicitComponent):
     """
     Scale the wind frame coordinates to get the Prandtl-Glauert transformed
     geometry.
@@ -232,7 +232,7 @@ class ScaleToPrandtlGlauert(ExplicitComponent):
             partials[of_name, wrt_name] = np.tile(fact_norm, nn)
 
 
-class ScaleFromPrandtlGlauert(ExplicitComponent):
+class ScaleFromPrandtlGlauert(om.ExplicitComponent):
     """
     Scale the Prandtl-Glauert transformed forces to get the physical forces
     Prandtl-Glauert transformed geometry.

--- a/openaerostruct/aerodynamics/pg_transform.py
+++ b/openaerostruct/aerodynamics/pg_transform.py
@@ -1,10 +1,10 @@
-from openmdao.api import Group
+import openmdao.api as om
 
 from openaerostruct.aerodynamics.pg_wind_rotation import RotateToWindFrame, RotateFromWindFrame
 from openaerostruct.aerodynamics.pg_scale import ScaleToPrandtlGlauert, ScaleFromPrandtlGlauert
 
 
-class PGTransform(Group):
+class PGTransform(om.Group):
     """
     This group is responsible for transforming the VLM geometries from
     physical coordinates to Prandtl-Glauert coordinates. This allows the
@@ -41,7 +41,7 @@ class PGTransform(Group):
                            promotes_outputs=['*'])
 
 
-class InversePGTransform(Group):
+class InversePGTransform(om.Group):
     """
     This group is responsible for transforming the solved incompressible
     forces in the Prandtl-Glauert domain to the compressible forces in the

--- a/openaerostruct/aerodynamics/pg_wind_rotation.py
+++ b/openaerostruct/aerodynamics/pg_wind_rotation.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class RotateToWindFrame(ExplicitComponent):
+class RotateToWindFrame(om.ExplicitComponent):
     """
     Rotate the VLM Geometry from the standard aerodynamic to the wind frame.
     In the wind frame the freestream will be along the x-axis.
@@ -237,7 +237,7 @@ class RotateToWindFrame(ExplicitComponent):
             partials[of_name, wrt_name] = np.tile(Tw, nn)
 
 
-class RotateFromWindFrame(ExplicitComponent):
+class RotateFromWindFrame(om.ExplicitComponent):
     """
     Rotate the aerodynamic sectional and nodal force vectors from the wind to
     the standard aerodynamic frame. This is the reverse operation of the

--- a/openaerostruct/aerodynamics/rotational_velocity.py
+++ b/openaerostruct/aerodynamics/rotational_velocity.py
@@ -2,10 +2,10 @@ from __future__ import print_function
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class RotationalVelocity(ExplicitComponent):
+class RotationalVelocity(om.ExplicitComponent):
     """
     Compute the velocity due to rigid body rotation.
 

--- a/openaerostruct/aerodynamics/solve_matrix.py
+++ b/openaerostruct/aerodynamics/solve_matrix.py
@@ -2,10 +2,10 @@ from __future__ import print_function
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
 
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
 
-class SolveMatrix(ImplicitComponent):
+class SolveMatrix(om.ImplicitComponent):
     """
     Solve the AIC linear system to obtain the vortex ring circulations.
 

--- a/openaerostruct/aerodynamics/states.py
+++ b/openaerostruct/aerodynamics/states.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.aerodynamics.get_vectors import GetVectors
 from openaerostruct.aerodynamics.collocation_points import CollocationPoints
 from openaerostruct.aerodynamics.eval_mtx import EvalVelMtx
@@ -14,7 +14,7 @@ from openaerostruct.aerodynamics.panel_forces_surf import PanelForcesSurf
 from openaerostruct.aerodynamics.vortex_mesh import VortexMesh
 
 
-class VLMStates(Group):
+class VLMStates(om.Group):
     """
     Group that houses all components to compute the aerodynamic states.
     """

--- a/openaerostruct/aerodynamics/tests/test_convert_velocity.py
+++ b/openaerostruct/aerodynamics/tests/test_convert_velocity.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from openaerostruct.aerodynamics.convert_velocity import ConvertVelocity
@@ -23,7 +23,7 @@ class Test(unittest.TestCase):
 
         comp = ConvertVelocity(surfaces=surfaces, rotational=True)
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
         prob.setup(force_alloc_complex=True)
 

--- a/openaerostruct/aerodynamics/tests/test_eval_mtx.py
+++ b/openaerostruct/aerodynamics/tests/test_eval_mtx.py
@@ -1,5 +1,5 @@
 import unittest
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from openaerostruct.aerodynamics.eval_mtx import EvalVelMtx
@@ -20,11 +20,10 @@ class Test(unittest.TestCase):
 
         comp = EvalVelMtx(surfaces=surfaces, num_eval_points=2, eval_name='test_name')
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
 
-        from openmdao.api import DirectSolver
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
         prob.model.options['assembled_jac_type'] = 'csc'
 
         prob.setup(force_alloc_complex=True)

--- a/openaerostruct/aerodynamics/tests/test_geometry.py
+++ b/openaerostruct/aerodynamics/tests/test_geometry.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp, Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
 
 from openaerostruct.aerodynamics.geometry import VLMGeometry
@@ -14,11 +14,11 @@ class Test(unittest.TestCase):
     def test(self):
         surfaces = get_default_surfaces()
 
-        group = Group()
+        group = om.Group()
 
         comp = VLMGeometry(surface=surfaces[0])
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         indep_var_comp.add_output('def_mesh', val=surfaces[0]['mesh'], units='m')
 
@@ -83,12 +83,12 @@ class Test(unittest.TestCase):
         #surfaces = get_default_surfaces()
         surfaces = [surface]
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         comp = VLMGeometry(surface=surfaces[0])
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('def_mesh', val=surfaces[0]['mesh'], units='m')
 
         group.add_subsystem('geom', comp)
@@ -160,12 +160,12 @@ class Test(unittest.TestCase):
         #surfaces = get_default_surfaces()
         surfaces = [surface]
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         comp = VLMGeometry(surface=surfaces[0])
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('def_mesh', val=surfaces[0]['mesh'], units='m')
 
         group.add_subsystem('geom', comp)
@@ -186,18 +186,18 @@ class Test(unittest.TestCase):
     def test_outputs(self):
         surfaces = get_default_surfaces()
 
-        group = Group()
+        group = om.Group()
 
         comp = VLMGeometry(surface=surfaces[0])
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         indep_var_comp.add_output('def_mesh', val=surfaces[0]['mesh'], units='m')
 
         group.add_subsystem('geom', comp, promotes=['*'])
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('group', group, promotes=['*'])
         prob.setup()
         prob.run_model()

--- a/openaerostruct/aerodynamics/tests/test_lift_drag.py
+++ b/openaerostruct/aerodynamics/tests/test_lift_drag.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from openaerostruct.aerodynamics.lift_drag import LiftDrag
@@ -25,7 +25,7 @@ class Test(unittest.TestCase):
         # Use Tail since it is not symmetric.
         comp = LiftDrag(surface=surfaces[1])
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
         prob.setup(force_alloc_complex=True)
 

--- a/openaerostruct/aerodynamics/tests/test_mesh_point_forces.py
+++ b/openaerostruct/aerodynamics/tests/test_mesh_point_forces.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from openaerostruct.aerodynamics.mesh_point_forces import MeshPointForces
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
         #surfaces = get_default_surfaces()
         surfaces = [surface]
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         comp = MeshPointForces(surfaces=surfaces)

--- a/openaerostruct/aerodynamics/tests/test_pg_transform.py
+++ b/openaerostruct/aerodynamics/tests/test_pg_transform.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from openaerostruct.aerodynamics.pg_transform import PGTransform
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
 
         comp = RotateToWindFrame(surfaces=surfaces, rotational=True)
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
         prob.setup(force_alloc_complex=True)
 
@@ -43,7 +43,7 @@ class Test(unittest.TestCase):
 
         comp = RotateFromWindFrame(surfaces=surfaces)
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
         prob.setup(force_alloc_complex=True)
 
@@ -63,7 +63,7 @@ class Test(unittest.TestCase):
 
         comp = ScaleToPrandtlGlauert(surfaces=surfaces, rotational=True)
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
         prob.setup(force_alloc_complex=True)
 
@@ -87,7 +87,7 @@ class Test(unittest.TestCase):
 
         comp = ScaleFromPrandtlGlauert(surfaces=surfaces)
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
         prob.setup(force_alloc_complex=True)
 

--- a/openaerostruct/aerodynamics/tests/test_rotational_velocity.py
+++ b/openaerostruct/aerodynamics/tests/test_rotational_velocity.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from openaerostruct.aerodynamics.rotational_velocity import RotationalVelocity
@@ -23,7 +23,7 @@ class Test(unittest.TestCase):
 
         comp = RotationalVelocity(surfaces=surfaces)
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('comp', comp)
         prob.setup(force_alloc_complex=True)
 

--- a/openaerostruct/aerodynamics/tests/test_solve_matrix.py
+++ b/openaerostruct/aerodynamics/tests/test_solve_matrix.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 
 from openaerostruct.aerodynamics.solve_matrix import SolveMatrix
 from openaerostruct.utils.testing import run_test, get_default_surfaces
@@ -12,10 +12,10 @@ class Test(unittest.TestCase):
     def test(self):
         surfaces = get_default_surfaces()
 
-        group = Group()
+        group = om.Group()
         comp = SolveMatrix(surfaces=surfaces)
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         system_size = 0
         for surface in surfaces:

--- a/openaerostruct/aerodynamics/tests/test_viscous_drag.py
+++ b/openaerostruct/aerodynamics/tests/test_viscous_drag.py
@@ -20,12 +20,14 @@ class Test(unittest.TestCase):
         indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
-
-        group.add_subsystem('t_over_c_bsp', om.BsplinesComp(
-            in_name='t_over_c_cp', out_name='t_over_c',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
+        
+        x_interp = np.linspace(0., 1., int(ny-1))
+        comp = group.add_subsystem('t_over_c_bsp', om.SplineComp(
+            method='bsplines', x_interp_val=x_interp,
+            num_cp=n_cp,
+            interp_options={'order' : min(n_cp, 4)}),
             promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
+        comp.add_spline(y_cp_name='t_over_c_cp', y_interp_name='t_over_c', y_cp_val=np.zeros(n_cp))
 
         comp = ViscousDrag(surface=surface, with_viscous=True)
         group.add_subsystem('viscousdrag', comp, promotes=['*'])
@@ -45,12 +47,14 @@ class Test(unittest.TestCase):
         indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
-
-        group.add_subsystem('t_over_c_bsp', om.BsplinesComp(
-            in_name='t_over_c_cp', out_name='t_over_c',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
+        
+        x_interp = np.linspace(0., 1., int(ny-1))
+        comp = group.add_subsystem('t_over_c_bsp', om.SplineComp(
+            method='bsplines', x_interp_val=x_interp,
+            num_cp=n_cp,
+            interp_options={'order' : min(n_cp, 4)}),
             promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
+        comp.add_spline(y_cp_name='t_over_c_cp', y_interp_name='t_over_c')
 
         comp = ViscousDrag(surface=surface, with_viscous=True)
         group.add_subsystem('viscousdrag', comp, promotes=['*'])

--- a/openaerostruct/aerodynamics/tests/test_viscous_drag.py
+++ b/openaerostruct/aerodynamics/tests/test_viscous_drag.py
@@ -2,7 +2,7 @@ import unittest
 
 from openaerostruct.aerodynamics.viscous_drag import ViscousDrag
 from openaerostruct.utils.testing import run_test, get_default_surfaces
-from openmdao.api import Group, IndepVarComp, BsplinesComp
+import openmdao.api as om
 import numpy as np
 
 class Test(unittest.TestCase):
@@ -15,13 +15,13 @@ class Test(unittest.TestCase):
         ny = surface['mesh'].shape[1]
         n_cp = len(surface['t_over_c_cp'])
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
 
-        group.add_subsystem('t_over_c_bsp', BsplinesComp(
+        group.add_subsystem('t_over_c_bsp', om.BsplinesComp(
             in_name='t_over_c_cp', out_name='t_over_c',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -40,13 +40,13 @@ class Test(unittest.TestCase):
         ny = surface['mesh'].shape[1]
         n_cp = len(surface['t_over_c_cp'])
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
 
-        group.add_subsystem('t_over_c_bsp', BsplinesComp(
+        group.add_subsystem('t_over_c_bsp', om.BsplinesComp(
             in_name='t_over_c_cp', out_name='t_over_c',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),

--- a/openaerostruct/aerodynamics/tests/test_wave_drag.py
+++ b/openaerostruct/aerodynamics/tests/test_wave_drag.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from openaerostruct.aerodynamics.wave_drag import WaveDrag
 from openaerostruct.utils.testing import run_test, get_default_surfaces
-from openmdao.api import Group, IndepVarComp, BsplinesComp
+import openmdao.api as om
 import numpy as np
 
 class Test(unittest.TestCase):
@@ -16,9 +16,9 @@ class Test(unittest.TestCase):
         ny = surface['mesh'].shape[1]
         n_cp = len(surface['t_over_c_cp'])
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
         indep_var_comp.add_output('Mach_number', val=.95)
         indep_var_comp.add_output('CL', val=0.7)
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
         indep_var_comp.add_output('chords', val = np.array([ 2.72835132,  5.12528179,  7.88916016, 13.6189974]),units='m')
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
 
-        group.add_subsystem('t_over_c_bsp', BsplinesComp(
+        group.add_subsystem('t_over_c_bsp', om.BsplinesComp(
             in_name='t_over_c_cp', out_name='t_over_c',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),

--- a/openaerostruct/aerodynamics/tests/test_wave_drag.py
+++ b/openaerostruct/aerodynamics/tests/test_wave_drag.py
@@ -26,12 +26,14 @@ class Test(unittest.TestCase):
         indep_var_comp.add_output('cos_sweep', val = np.array([10.01555924,  9.80832351,  9.79003729]),units='m')
         indep_var_comp.add_output('chords', val = np.array([ 2.72835132,  5.12528179,  7.88916016, 13.6189974]),units='m')
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
-
-        group.add_subsystem('t_over_c_bsp', om.BsplinesComp(
-            in_name='t_over_c_cp', out_name='t_over_c',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
+        
+        x_interp = np.linspace(0., 1., int(ny-1))
+        comp = group.add_subsystem('t_over_c_bsp', om.SplineComp(
+            method='bsplines', x_interp_val=x_interp,
+            num_cp=n_cp,
+            interp_options={'order' : min(n_cp, 4)}),
             promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
+        comp.add_spline(y_cp_name='t_over_c_cp', y_interp_name='t_over_c')
 
         comp = WaveDrag(surface=surface)
         group.add_subsystem('wavedrag', comp, promotes=['*'])

--- a/openaerostruct/aerodynamics/total_drag.py
+++ b/openaerostruct/aerodynamics/total_drag.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, division
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class TotalDrag(ExplicitComponent):
+class TotalDrag(om.ExplicitComponent):
     """ Calculate total drag in force units.
 
     parameters

--- a/openaerostruct/aerodynamics/total_lift.py
+++ b/openaerostruct/aerodynamics/total_lift.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, division
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class TotalLift(ExplicitComponent):
+class TotalLift(om.ExplicitComponent):
     """
     Calculate total lift in force units by summing the induced CL
     with the CL0.

--- a/openaerostruct/aerodynamics/viscous_drag.py
+++ b/openaerostruct/aerodynamics/viscous_drag.py
@@ -1,9 +1,9 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class ViscousDrag(ExplicitComponent):
+class ViscousDrag(om.ExplicitComponent):
     """
     Compute the skin friction drag if the with_viscous option is True.
     If not, the CDv is 0.

--- a/openaerostruct/aerodynamics/vortex_mesh.py
+++ b/openaerostruct/aerodynamics/vortex_mesh.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class VortexMesh(ExplicitComponent):
+class VortexMesh(om.ExplicitComponent):
     """
     Compute the vortex mesh based on the deformed aerodynamic mesh.
 

--- a/openaerostruct/aerodynamics/wave_drag.py
+++ b/openaerostruct/aerodynamics/wave_drag.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class WaveDrag(ExplicitComponent):
+class WaveDrag(om.ExplicitComponent):
     """
     Compute the wave drag if the with_wave option is True. If not, the CDw is 0.
     This component exists for each lifting surface.

--- a/openaerostruct/common/atmos_comp.py
+++ b/openaerostruct/common/atmos_comp.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 import numpy as np
 from  scipy.interpolate import Akima1DInterpolator as Akima
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
 """United States standard atmosphere 1976 tables, data obtained from http://www.digitaldutch.com/atmoscalc/index.htm"""
@@ -80,7 +80,7 @@ a_interp_deriv = a_interp.derivative(1)
 viscosity_interp_deriv = viscosity_interp.derivative(1)
 
 
-class AtmosComp(ExplicitComponent):
+class AtmosComp(om.ExplicitComponent):
 
     def setup(self):
         self.add_input('altitude', val=1., units='ft')

--- a/openaerostruct/common/atmos_group.py
+++ b/openaerostruct/common/atmos_group.py
@@ -1,9 +1,9 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.common.reynolds_comp import ReynoldsComp
 from openaerostruct.common.atmos_comp import AtmosComp
 
 
-class AtmosGroup(Group):
+class AtmosGroup(om.Group):
 
     def setup(self):
         self.add_subsystem('atmos',

--- a/openaerostruct/common/reynolds_comp.py
+++ b/openaerostruct/common/reynolds_comp.py
@@ -19,4 +19,4 @@ class ReynoldsComp(om.ExplicitComponent):
     def compute_partials(self, inputs, partials):
         partials['re', 'rho'] = inputs['v'] / inputs['mu']
         partials['re', 'v'] = inputs['rho'] / inputs['mu']
-        partials['re', 'mu'] = -inputs['rho'] * inputs['v'] / inputs['mu']**-2
+        partials['re', 'mu'] = -inputs['rho'] * inputs['v'] / inputs['mu']**2

--- a/openaerostruct/common/reynolds_comp.py
+++ b/openaerostruct/common/reynolds_comp.py
@@ -19,4 +19,4 @@ class ReynoldsComp(om.ExplicitComponent):
     def compute_partials(self, inputs, partials):
         partials['re', 'rho'] = inputs['v'] / inputs['mu']
         partials['re', 'v'] = inputs['rho'] / inputs['mu']
-        partials['re', 'mu'] = -inputs['rho'] * inputs['v'] / inputs['mu']**2
+        partials['re', 'mu'] = - inputs['rho'] * inputs['v'] / inputs['mu']**2

--- a/openaerostruct/common/reynolds_comp.py
+++ b/openaerostruct/common/reynolds_comp.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ReynoldsComp(ExplicitComponent):
+class ReynoldsComp(om.ExplicitComponent):
 
     def setup(self):
         self.add_input('rho', val=1., units='slug/ft**3')

--- a/openaerostruct/common/tests/test_reynolds_comp.py
+++ b/openaerostruct/common/tests/test_reynolds_comp.py
@@ -1,15 +1,27 @@
 import unittest
-
+import numpy as np
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_check_partials
 from openaerostruct.common.reynolds_comp import ReynoldsComp
-from openaerostruct.utils.testing import run_test
 
 
 class Test(unittest.TestCase):
 
-    def test(self):
+    def test_reynolds_derivs(self):
         comp = ReynoldsComp()
 
-        run_test(self, comp, method='cs', complex_flag=True)
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', comp, promotes=['*'])
+        prob.setup(force_alloc_complex=True)
+
+        prob['rho'] = np.random.random()
+        prob['mu'] = np.random.random()
+        prob['v'] = np.random.random()
+        prob.run_model()
+
+        check = prob.check_partials(compact_print=True, method='cs', step=1e-40)
+
+        assert_check_partials(check)
 
 
 if __name__ == '__main__':

--- a/openaerostruct/docs/aero_walkthrough/part_1.py
+++ b/openaerostruct/docs/aero_walkthrough/part_1.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem, Group, SqliteRecorder
+import openmdao.api as om
 
 from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry

--- a/openaerostruct/docs/aero_walkthrough/part_3.py
+++ b/openaerostruct/docs/aero_walkthrough/part_3.py
@@ -1,9 +1,9 @@
 # Create the OpenMDAO problem
-prob = Problem()
+prob = om.Problem()
 
 # Create an independent variable component that will supply the flow
 # conditions to the problem.
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=248.136, units='m/s')
 indep_var_comp.add_output('alpha', val=5., units='deg')
 indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/docs/aero_walkthrough/part_5.py
+++ b/openaerostruct/docs/aero_walkthrough/part_5.py
@@ -1,10 +1,10 @@
 # Import the Scipy Optimizer and set the driver of the problem to use
 # it, which defaults to an SLSQP optimization method
-from openmdao.api import ScipyOptimizeDriver
-prob.driver = ScipyOptimizeDriver()
+import openmdao.api as om
+prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['tol'] = 1e-9
 
-recorder = SqliteRecorder("aero_analysis_test.db")
+recorder = om.SqliteRecorder("aero_analysis_test.db")
 prob.driver.add_recorder(recorder)
 prob.driver.recording_options['record_derivatives'] = True
 prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/docs/installation.rst
+++ b/openaerostruct/docs/installation.rst
@@ -3,7 +3,8 @@
 Installation
 ============
 
-To use OpenAeroStruct, you must first install OpenMDAO 2.3+ by installing via pip using:
+This version of OpenAeroStruct is only compatible with Python3.
+To use OpenAeroStruct, you must first install OpenMDAO 3.0+ by installing via pip using:
 
 .. code-block:: bash
 

--- a/openaerostruct/examples/black_box_example.py
+++ b/openaerostruct/examples/black_box_example.py
@@ -15,7 +15,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 # Create a dictionary to store options about the surface
@@ -73,10 +73,10 @@ surface = {
             }
 
 # Create the problem and assign the model group
-prob = Problem()
+prob = om.Problem()
 
 # Add problem information as an independent variables component
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=248.136, units='m/s')
 indep_var_comp.add_output('alpha', val=5., units='deg')
 indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/examples/drag_polar.py
+++ b/openaerostruct/examples/drag_polar.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function
 import numpy as np
 import matplotlib.pylab as plt
 
-from openmdao.api import IndepVarComp, Problem, NewtonSolver, BroydenSolver, \
+import openmdao.api as om
             DirectSolver, BalanceComp, ArmijoGoldsteinLS, BoundsEnforceLS, \
             NonlinearBlockGS
 from openaerostruct.geometry.utils import generate_mesh
@@ -18,10 +18,10 @@ def compute_drag_polar(Mach, alphas, surfaces, trimmed=False):
         surfaces = [surfaces,]
 
     # Create the OpenMDAO problem
-    prob = Problem()
+    prob = om.Problem()
     # Create an independent variable component that will supply the flow
     # conditions to the problem.
-    indep_var_comp = IndepVarComp()
+    indep_var_comp = om.IndepVarComp()
     indep_var_comp.add_output('v', val=248.136, units='m/s')
     indep_var_comp.add_output('alpha', val=0., units = 'deg')
     indep_var_comp.add_output('Mach_number', val=Mach)
@@ -63,11 +63,11 @@ def compute_drag_polar(Mach, alphas, surfaces, trimmed=False):
         prob.model.connect('aero.CM', 'balance.lhs:tail_rotation', src_indices = [1])
         prob.model.connect('tail_rotation', 'tail.twist_cp')
 
-        prob.model.nonlinear_solver = NonlinearBlockGS(use_aitken=True)
+        prob.model.nonlinear_solver = om.NonlinearBlockGS(use_aitken=True)
 
         prob.model.nonlinear_solver.options['iprint'] = 2
         prob.model.nonlinear_solver.options['maxiter'] = 100
-        prob.model.linear_solver = DirectSolver()
+        prob.model.linear_solver = om.DirectSolver()
 
 
     prob.setup()

--- a/openaerostruct/examples/rectangular_wing/drag_polar.py
+++ b/openaerostruct/examples/rectangular_wing/drag_polar.py
@@ -5,7 +5,7 @@ attacks. Plot drag polar at end. Check output directory for Tecplot solution fil
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 
 from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
@@ -13,10 +13,10 @@ from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
 
 # Instantiate the problem and the model group
-prob = Problem()
+prob = om.Problem()
 
 # Define flight variables as independent variables of the model
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=248.136, units='m/s') # Freestream Velocity
 indep_var_comp.add_output('alpha', val=5., units='deg') # Angle of Attack
 indep_var_comp.add_output('beta', val=0., units='deg') # Sideslip angle

--- a/openaerostruct/examples/rectangular_wing/opt_chord.py
+++ b/openaerostruct/examples/rectangular_wing/opt_chord.py
@@ -8,7 +8,7 @@ solution files.
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 
 from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
@@ -16,10 +16,10 @@ from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
 
 # Instantiate the problem and the model group
-prob = Problem()
+prob = om.Problem()
 
 # Define flight variables as independent variables of the model
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=248.136, units='m/s') # Freestream Velocity
 indep_var_comp.add_output('alpha', val=5., units='deg') # Angle of Attack
 indep_var_comp.add_output('beta', val=0., units='deg') # Sideslip angle
@@ -100,8 +100,7 @@ prob.model.connect(name + '.mesh', point_name + '.' + name + '.def_mesh')
 prob.model.connect(name + '.mesh', point_name + '.aero_states.' + name + '_def_mesh')
 
 # Set optimizer as model driver
-from openmdao.api import ScipyOptimizeDriver
-prob.driver = ScipyOptimizeDriver()
+prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['debug_print'] = ['nl_cons','objs', 'desvars']
 
 # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/examples/rectangular_wing/opt_twist.py
+++ b/openaerostruct/examples/rectangular_wing/opt_twist.py
@@ -7,7 +7,7 @@ Tecplot solution files.
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 
 from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
@@ -15,10 +15,10 @@ from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
 
 # Instantiate the problem and the model group
-prob = Problem()
+prob = om.Problem()
 
 # Define flight variables as independent variables of the model
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=248.136, units='m/s') # Freestream Velocity
 indep_var_comp.add_output('alpha', val=5., units='deg') # Angle of Attack
 indep_var_comp.add_output('beta', val=0., units='deg') # Sideslip angle
@@ -99,8 +99,7 @@ prob.model.connect(name + '.mesh', point_name + '.' + name + '.def_mesh')
 prob.model.connect(name + '.mesh', point_name + '.aero_states.' + name + '_def_mesh')
 
 # Set optimizer as model driver
-from openmdao.api import ScipyOptimizeDriver
-prob.driver = ScipyOptimizeDriver()
+prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['debug_print'] = ['nl_cons','objs', 'desvars']
 
 # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/examples/rectangular_wing/run_rect_wing.py
+++ b/openaerostruct/examples/rectangular_wing/run_rect_wing.py
@@ -5,7 +5,7 @@ Tecplot solution files.
 '''
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 
 from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
@@ -13,10 +13,10 @@ from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
 
 # Instantiate the problem and the model group
-prob = Problem()
+prob = om.Problem()
 
 # Define flight variables as independent variables of the model
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=248.136, units='m/s') # Freestream Velocity
 indep_var_comp.add_output('alpha', val=5., units='deg') # Angle of Attack
 indep_var_comp.add_output('beta', val=0., units='deg') # Sideslip angle
@@ -101,8 +101,7 @@ prob.model.connect(name + '.mesh', point_name + '.aero_states.' + name + '_def_m
 prob.setup()
 
 # Create a n^2 diagram for user to view model connections
-from openmdao.api import view_model
-view_model(prob)
+om.view_model(prob)
 
 # Run analysis
 prob.run_model()

--- a/openaerostruct/examples/rectangular_wing/run_roll.py
+++ b/openaerostruct/examples/rectangular_wing/run_roll.py
@@ -6,7 +6,7 @@ for Tecplot solution files.
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 
 from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
@@ -14,10 +14,10 @@ from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
 
 # Instantiate the problem and the model group
-prob = Problem()
+prob = om.Problem()
 
 # Define flight variables as independent variables of the model
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=50.0, units='m/s') # Freestream Velocity
 indep_var_comp.add_output('alpha', val=5., units='deg') # Angle of Attack
 indep_var_comp.add_output('beta', val=0., units='deg') # Sideslip angle

--- a/openaerostruct/examples/run_CRM.py
+++ b/openaerostruct/examples/run_CRM.py
@@ -5,7 +5,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, SqliteRecorder
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 # Create a dictionary to store options about the surface
@@ -63,10 +63,10 @@ surface = {
             }
 
 # Create the problem and assign the model group
-prob = Problem()
+prob = om.Problem()
 
 # Add problem information as an independent variables component
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=248.136, units='m/s')
 indep_var_comp.add_output('alpha', val=5., units='deg')
 indep_var_comp.add_output('Mach_number', val=0.84)
@@ -114,11 +114,10 @@ prob.model.connect(name + '.cg_location', point_name + '.' + 'total_perf.' + nam
 prob.model.connect(name + '.structural_mass', point_name + '.' + 'total_perf.' + name + '_structural_mass')
 prob.model.connect(name + '.t_over_c', com_name + '.t_over_c')
 
-from openmdao.api import ScipyOptimizeDriver
-prob.driver = ScipyOptimizeDriver()
+prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['tol'] = 1e-9
 
-recorder = SqliteRecorder("aerostruct.db")
+recorder = om.SqliteRecorder("aerostruct.db")
 prob.driver.add_recorder(recorder)
 prob.driver.recording_options['record_derivatives'] = True
 prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/examples/run_aerostruct_uCRM_multipoint.py
+++ b/openaerostruct/examples/run_aerostruct_uCRM_multipoint.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
-from openmdao.api import IndepVarComp, Problem, ScipyOptimizeDriver, SqliteRecorder, ExecComp
+import openmdao.api as om
 from openaerostruct.structures.wingbox_fuel_vol_delta import WingboxFuelVolDelta
 from openaerostruct.utils.constants import grav_constant
 
@@ -111,10 +111,10 @@ surf_dict = {
 surfaces = [surf_dict]
 
 # Create the problem and assign the model group
-prob = Problem()
+prob = om.Problem()
 
 # Add problem information as an independent variables component
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=np.array([.85 * 295.07, .64 * 340.294]), units='m/s')
 indep_var_comp.add_output('alpha', val=0., units='deg')
 indep_var_comp.add_output('alpha_maneuver', val=0., units='deg')
@@ -219,7 +219,7 @@ if surf_dict['distributed_fuel_weight']:
     prob.model.connect('wing.struct_setup.fuel_vols', 'AS_point_1.coupled.wing.struct_states.fuel_vols')
     prob.model.connect('fuel_mass', 'AS_point_1.coupled.wing.struct_states.fuel_mass')
 
-comp = ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
+comp = om.ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
 prob.model.add_subsystem('fuel_diff', comp,
     promotes_inputs=['fuel_mass'],
     promotes_outputs=['fuel_diff'])
@@ -227,20 +227,19 @@ prob.model.connect('AS_point_0.fuelburn', 'fuel_diff.fuelburn')
 
 
 ## Use these settings if you do not have pyOptSparse or SNOPT
-prob.driver = ScipyOptimizeDriver()
+prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['optimizer'] = 'SLSQP'
 prob.driver.options['tol'] = 1e-8
 
 # # The following are the optimizer settings used for the EngOpt conference paper
 # # Uncomment them if you can use SNOPT
-# from openmdao.api import pyOptSparseDriver
-# prob.driver = pyOptSparseDriver()
+# prob.driver = om.pyOptSparseDriver()
 # prob.driver.options['optimizer'] = "SNOPT"
 # prob.driver.opt_settings['Major optimality tolerance'] = 5e-6
 # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
 # prob.driver.opt_settings['Major iterations limit'] = 200
 
-recorder = SqliteRecorder("aerostruct.db")
+recorder = om.SqliteRecorder("aerostruct.db")
 prob.driver.add_recorder(recorder)
 
 # We could also just use prob.driver.recording_options['includes']=['*'] here, but for large meshes the database file becomes extremely large. So we just select the variables we need.
@@ -295,8 +294,7 @@ prob.model.add_constraint('fuel_diff', equals=0.)
 # Set up the problem
 prob.setup()
 
-# from openmdao.api import view_model
-# view_model(prob)
+# om.view_model(prob)
 
 # prob.check_partials(form='central', compact_print=True)
 
@@ -392,10 +390,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=np.array([.85 * 295.07, .64 * 340.294]), units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('alpha_maneuver', val=0., units='deg')
@@ -500,7 +498,7 @@ class Test(unittest.TestCase):
             prob.model.connect('wing.struct_setup.fuel_vols', 'AS_point_1.coupled.wing.struct_states.fuel_vols')
             prob.model.connect('fuel_mass', 'AS_point_1.coupled.wing.struct_states.fuel_mass')
 
-        comp = ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
+        comp = om.ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
         prob.model.add_subsystem('fuel_diff', comp,
             promotes_inputs=['fuel_mass'],
             promotes_outputs=['fuel_diff'])
@@ -508,11 +506,11 @@ class Test(unittest.TestCase):
 
 
         ## Use these settings if you do not have pyOptSparse or SNOPT
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-8
 
-        recorder = SqliteRecorder("unit_test.db")
+        recorder = om.SqliteRecorder("unit_test.db")
         prob.driver.add_recorder(recorder)
 
         # We could also just use prob.driver.recording_options['includes']=['*'] here, but for large meshes the database file becomes extremely large. So we just select the variables we need.

--- a/openaerostruct/examples/run_scaneagle.py
+++ b/openaerostruct/examples/run_scaneagle.py
@@ -16,7 +16,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, SqliteRecorder
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 # Total number of nodes to use in the spanwise (num_y) and
@@ -113,10 +113,10 @@ surface = {
             }
 
 # Create the problem and assign the model group
-prob = Problem()
+prob = om.Problem()
 
 # Add problem information as an independent variables component
-indep_var_comp = IndepVarComp()
+indep_var_comp = om.IndepVarComp()
 indep_var_comp.add_output('v', val=22.876, units='m/s')
 indep_var_comp.add_output('alpha', val=5., units='deg')
 indep_var_comp.add_output('Mach_number', val=0.071)
@@ -171,12 +171,11 @@ prob.model.connect(name + '.structural_mass', point_name + '.' + 'total_perf.' +
 prob.model.connect(name + '.t_over_c', com_name + '.t_over_c')
 
 # Set the optimizer type
-from openmdao.api import ScipyOptimizeDriver
-prob.driver = ScipyOptimizeDriver()
+prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['tol'] = 1e-7
 
 # Record data from this problem so we can visualize it using plot_wing
-recorder = SqliteRecorder("aerostruct.db")
+recorder = om.SqliteRecorder("aerostruct.db")
 prob.driver.add_recorder(recorder)
 prob.driver.recording_options['record_derivatives'] = True
 prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/functionals/breguet_range.py
+++ b/openaerostruct/functionals/breguet_range.py
@@ -1,10 +1,10 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class BreguetRange(ExplicitComponent):
+class BreguetRange(om.ExplicitComponent):
     """
     Computes the fuel burn using the Breguet range equation using
     the computed CL, CD, weight, and provided specific fuel consumption, speed of sound,

--- a/openaerostruct/functionals/center_of_gravity.py
+++ b/openaerostruct/functionals/center_of_gravity.py
@@ -1,11 +1,11 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
-class CenterOfGravity(ExplicitComponent):
+class CenterOfGravity(om.ExplicitComponent):
     """
     Compute the center of gravity of the entire aircraft based on the inputted W0
     and its corresponding cg and the weighted sum of each surface's structural

--- a/openaerostruct/functionals/equilibrium.py
+++ b/openaerostruct/functionals/equilibrium.py
@@ -1,9 +1,9 @@
 from __future__ import division, print_function
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
-class Equilibrium(ExplicitComponent):
+class Equilibrium(om.ExplicitComponent):
     """
     Computes L_equals_W, which is a normalized measure of the weight of the
     aircraft minus the total generated lift. So if L_equals_W is positive,

--- a/openaerostruct/functionals/moment_coefficient.py
+++ b/openaerostruct/functionals/moment_coefficient.py
@@ -1,10 +1,10 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MomentCoefficient(ExplicitComponent):
+class MomentCoefficient(om.ExplicitComponent):
     """
     Compute the coefficient of moment (CM) for the entire aircraft.
 

--- a/openaerostruct/functionals/sum_areas.py
+++ b/openaerostruct/functionals/sum_areas.py
@@ -1,8 +1,8 @@
 from __future__ import division, print_function
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class SumAreas(ExplicitComponent):
+class SumAreas(om.ExplicitComponent):
     """
     Compute the total surface area of the entire aircraft as a sum of its
     individual surfaces' surface areas.

--- a/openaerostruct/functionals/tests/test_moment_coefficient.py
+++ b/openaerostruct/functionals/tests/test_moment_coefficient.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 
 from openaerostruct.functionals.moment_coefficient import MomentCoefficient
 from openaerostruct.utils.testing import run_test, get_default_surfaces
@@ -29,11 +29,11 @@ class Test(unittest.TestCase):
     def test2(self):
         surfaces = get_default_surfaces()
 
-        group = Group()
+        group = om.Group()
 
         comp = MomentCoefficient(surfaces=surfaces)
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         indep_var_comp.add_output('S_ref_total', val=1e4, units='m**2')
 

--- a/openaerostruct/functionals/tests/test_total_lift_drag.py
+++ b/openaerostruct/functionals/tests/test_total_lift_drag.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 
 from openaerostruct.functionals.total_lift_drag import TotalLiftDrag
 from openaerostruct.utils.testing import run_test, get_default_surfaces
@@ -28,11 +28,11 @@ class Test(unittest.TestCase):
     def test2(self):
         surfaces = get_default_surfaces()
 
-        group = Group()
+        group = om.Group()
 
         comp = TotalLiftDrag(surfaces=surfaces)
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         indep_var_comp.add_output('S_ref_total', val=10., units='m**2')
 

--- a/openaerostruct/functionals/total_aero_performance.py
+++ b/openaerostruct/functionals/total_aero_performance.py
@@ -1,13 +1,13 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import Group
+import openmdao.api as om
 
 from openaerostruct.functionals.moment_coefficient import MomentCoefficient
 from openaerostruct.functionals.total_lift_drag import TotalLiftDrag
 from openaerostruct.functionals.sum_areas import SumAreas
 
-class TotalAeroPerformance(Group):
+class TotalAeroPerformance(om.Group):
     """
     Group to contain the total aerodynamic performance components.
     """

--- a/openaerostruct/functionals/total_lift_drag.py
+++ b/openaerostruct/functionals/total_lift_drag.py
@@ -1,9 +1,9 @@
 from __future__ import division, print_function
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class TotalLiftDrag(ExplicitComponent):
+class TotalLiftDrag(om.ExplicitComponent):
     """
     Compute the coefficients of lift (CL) and drag (CD) for the entire aircraft,
     based on the area-weighted sum of individual surfaces' CLs and CDs.

--- a/openaerostruct/functionals/total_performance.py
+++ b/openaerostruct/functionals/total_performance.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function
 
-from openmdao.api import Group
+import openmdao.api as om
 
 from openaerostruct.functionals.breguet_range import BreguetRange
 from openaerostruct.functionals.equilibrium import Equilibrium
@@ -10,7 +10,7 @@ from openaerostruct.functionals.total_lift_drag import TotalLiftDrag
 from openaerostruct.functionals.sum_areas import SumAreas
 
 
-class TotalPerformance(Group):
+class TotalPerformance(om.Group):
     """
     Group to contain the total aerostructural performance components.
     """

--- a/openaerostruct/geometry/ffd_component.py
+++ b/openaerostruct/geometry/ffd_component.py
@@ -3,14 +3,14 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 try:
     from pygeo import DVGeometry
 except:
     pass
 
 
-class GeometryMesh(ExplicitComponent):
+class GeometryMesh(om.ExplicitComponent):
     """
     OpenMDAO component that performs mesh manipulation functions. It reads in
     the initial mesh from the surface dictionary and outputs the altered

--- a/openaerostruct/geometry/geometry_group.py
+++ b/openaerostruct/geometry/geometry_group.py
@@ -62,12 +62,14 @@ class Geometry(om.Group):
 
             if 't_over_c_cp' in surface.keys():
                 n_cp = len(surface['t_over_c_cp'])
-                # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('t_over_c_bsp', om.BsplinesComp(
-                    in_name='t_over_c_cp', out_name='t_over_c',
-                    num_control_points=n_cp, num_points=int(ny-1),
-                    bspline_order=min(n_cp, 4), distribution='uniform'),
+                # Add bspline components for active bspline geometric variables.        
+                x_interp = np.linspace(0., 1., int(ny-1))
+                comp = self.add_subsystem('t_over_c_bsp', om.SplineComp(
+                    method='bsplines', x_interp_val=x_interp,
+                    num_cp=n_cp,
+                    interp_options={'order' : min(n_cp, 4)}),
                     promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
+                comp.add_spline(y_cp_name='t_over_c_cp', y_interp_name='t_over_c')
                 if surface.get('t_over_c_cp_dv', True):
                     indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
 
@@ -84,11 +86,13 @@ class Geometry(om.Group):
             if 'twist_cp' in surface.keys():
                 n_cp = len(surface['twist_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('twist_bsp', om.BsplinesComp(
-                    in_name='twist_cp', out_name='twist', units='deg',
-                    num_control_points=n_cp, num_points=int(ny),
-                    bspline_order=min(n_cp, 4), distribution='uniform'),
+                x_interp = np.linspace(0., 1., int(ny))
+                comp = self.add_subsystem('twist_bsp', om.SplineComp(
+                    method='bsplines', x_interp_val=x_interp,
+                    num_cp=n_cp,
+                    interp_options={'order' : min(n_cp, 4)}),
                     promotes_inputs=['twist_cp'], promotes_outputs=['twist'])
+                comp.add_spline(y_cp_name='twist_cp', y_interp_name='twist')
                 bsp_inputs.append('twist')
 
                 # Since default assumption is that we want tail rotation as a design variable, add this to allow for trimmed drag polar where the tail rotation should not be a design variable
@@ -98,11 +102,13 @@ class Geometry(om.Group):
             if 'chord_cp' in surface.keys():
                 n_cp = len(surface['chord_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('chord_bsp', om.BsplinesComp(
-                    in_name='chord_cp', out_name='chord', units='m',
-                    num_control_points=n_cp, num_points=int(ny),
-                    bspline_order=min(n_cp, 4), distribution='uniform'),
+                x_interp = np.linspace(0., 1., int(ny))
+                comp = self.add_subsystem('chord_bsp', om.SplineComp(
+                    method='bsplines', x_interp_val=x_interp,
+                    num_cp=n_cp,
+                    interp_options={'order' : min(n_cp, 4)}),
                     promotes_inputs=['chord_cp'], promotes_outputs=['chord'])
+                comp.add_spline(y_cp_name='chord_cp', y_interp_name='chord')
                 bsp_inputs.append('chord')
                 if surface.get('chord_cp_dv', True):
                     indep_var_comp.add_output('chord_cp', val=surface['chord_cp'], units='m')
@@ -110,22 +116,26 @@ class Geometry(om.Group):
             if 't_over_c_cp' in surface.keys():
                 n_cp = len(surface['t_over_c_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('t_over_c_bsp', om.BsplinesComp(
-                    in_name='t_over_c_cp', out_name='t_over_c',
-                    num_control_points=n_cp, num_points=int(ny-1),
-                    bspline_order=min(n_cp, 4), distribution='uniform'),
+                x_interp = np.linspace(0., 1., int(ny-1))
+                comp = self.add_subsystem('t_over_c_bsp', om.SplineComp(
+                    method='bsplines', x_interp_val=x_interp,
+                    num_cp=n_cp,
+                    interp_options={'order' : min(n_cp, 4)}),
                     promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
+                comp.add_spline(y_cp_name='t_over_c_cp', y_interp_name='t_over_c')
                 if surface.get('t_over_c_cp_dv', True):
                     indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
 
             if 'xshear_cp' in surface.keys():
                 n_cp = len(surface['xshear_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('xshear_bsp', om.BsplinesComp(
-                    in_name='xshear_cp', out_name='xshear', units='m',
-                    num_control_points=n_cp, num_points=int(ny),
-                    bspline_order=min(n_cp, 4), distribution='uniform'),
+                x_interp = np.linspace(0., 1., int(ny))
+                comp = self.add_subsystem('xshear_bsp', om.SplineComp(
+                    method='bsplines', x_interp_val=x_interp,
+                    num_cp=n_cp,
+                    interp_options={'order' : min(n_cp, 4)}),
                     promotes_inputs=['xshear_cp'], promotes_outputs=['xshear'])
+                comp.add_spline(y_cp_name='xshear_cp', y_interp_name='xshear')
                 bsp_inputs.append('xshear')
                 if surface.get('xshear_cp_dv', True):
                     indep_var_comp.add_output('xshear_cp', val=surface['xshear_cp'], units='m')
@@ -133,11 +143,13 @@ class Geometry(om.Group):
             if 'yshear_cp' in surface.keys():
                 n_cp = len(surface['yshear_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('yshear_bsp', om.BsplinesComp(
-                    in_name='yshear_cp', out_name='yshear', units='m',
-                    num_control_points=n_cp, num_points=int(ny),
-                    bspline_order=min(n_cp, 4), distribution='uniform'),
+                x_interp = np.linspace(0., 1., int(ny))
+                comp = self.add_subsystem('yshear_bsp', om.SplineComp(
+                    method='bsplines', x_interp_val=x_interp,
+                    num_cp=n_cp,
+                    interp_options={'order' : min(n_cp, 4)}),
                     promotes_inputs=['yshear_cp'], promotes_outputs=['yshear'])
+                comp.add_spline(y_cp_name='yshear_cp', y_interp_name='yshear')
                 bsp_inputs.append('yshear')
                 if surface.get('yshear_cp_dv', True):
                     indep_var_comp.add_output('yshear_cp', val=surface['yshear_cp'], units='m')
@@ -145,11 +157,13 @@ class Geometry(om.Group):
             if 'zshear_cp' in surface.keys():
                 n_cp = len(surface['zshear_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('zshear_bsp', om.BsplinesComp(
-                    in_name='zshear_cp', out_name='zshear', units='m',
-                    num_control_points=n_cp, num_points=int(ny),
-                    bspline_order=min(n_cp, 4), distribution='uniform'),
+                x_interp = np.linspace(0., 1., int(ny))
+                comp = self.add_subsystem('zshear_bsp', om.SplineComp(
+                    method='bsplines', x_interp_val=x_interp,
+                    num_cp=n_cp,
+                    interp_options={'order' : min(n_cp, 4)}),
                     promotes_inputs=['zshear_cp'], promotes_outputs=['zshear'])
+                comp.add_spline(y_cp_name='zshear_cp', y_interp_name='zshear')
                 bsp_inputs.append('zshear')
                 if surface.get('zshear_cp_dv', True):
                     indep_var_comp.add_output('zshear_cp', val=surface['zshear_cp'], units='m')

--- a/openaerostruct/geometry/geometry_group.py
+++ b/openaerostruct/geometry/geometry_group.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import IndepVarComp, Group, BsplinesComp
+import openmdao.api as om
 
 
-class Geometry(Group):
+class Geometry(om.Group):
     """
     Group that contains all components needed for any type of OAS problem.
 
@@ -39,7 +39,7 @@ class Geometry(Group):
 
         if make_ivc or self.options['DVGeo']:
             # Add independent variables that do not belong to a specific component
-            indep_var_comp = IndepVarComp()
+            indep_var_comp = om.IndepVarComp()
 
             # If connect_geom_DVs is true, then we promote all of the geometric
             # design variables to their appropriate manipulation functions.
@@ -63,7 +63,7 @@ class Geometry(Group):
             if 't_over_c_cp' in surface.keys():
                 n_cp = len(surface['t_over_c_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('t_over_c_bsp', BsplinesComp(
+                self.add_subsystem('t_over_c_bsp', om.BsplinesComp(
                     in_name='t_over_c_cp', out_name='t_over_c',
                     num_control_points=n_cp, num_points=int(ny-1),
                     bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -84,7 +84,7 @@ class Geometry(Group):
             if 'twist_cp' in surface.keys():
                 n_cp = len(surface['twist_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('twist_bsp', BsplinesComp(
+                self.add_subsystem('twist_bsp', om.BsplinesComp(
                     in_name='twist_cp', out_name='twist', units='deg',
                     num_control_points=n_cp, num_points=int(ny),
                     bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -98,7 +98,7 @@ class Geometry(Group):
             if 'chord_cp' in surface.keys():
                 n_cp = len(surface['chord_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('chord_bsp', BsplinesComp(
+                self.add_subsystem('chord_bsp', om.BsplinesComp(
                     in_name='chord_cp', out_name='chord', units='m',
                     num_control_points=n_cp, num_points=int(ny),
                     bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -110,7 +110,7 @@ class Geometry(Group):
             if 't_over_c_cp' in surface.keys():
                 n_cp = len(surface['t_over_c_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('t_over_c_bsp', BsplinesComp(
+                self.add_subsystem('t_over_c_bsp', om.BsplinesComp(
                     in_name='t_over_c_cp', out_name='t_over_c',
                     num_control_points=n_cp, num_points=int(ny-1),
                     bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -121,7 +121,7 @@ class Geometry(Group):
             if 'xshear_cp' in surface.keys():
                 n_cp = len(surface['xshear_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('xshear_bsp', BsplinesComp(
+                self.add_subsystem('xshear_bsp', om.BsplinesComp(
                     in_name='xshear_cp', out_name='xshear', units='m',
                     num_control_points=n_cp, num_points=int(ny),
                     bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -133,7 +133,7 @@ class Geometry(Group):
             if 'yshear_cp' in surface.keys():
                 n_cp = len(surface['yshear_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('yshear_bsp', BsplinesComp(
+                self.add_subsystem('yshear_bsp', om.BsplinesComp(
                     in_name='yshear_cp', out_name='yshear', units='m',
                     num_control_points=n_cp, num_points=int(ny),
                     bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -145,7 +145,7 @@ class Geometry(Group):
             if 'zshear_cp' in surface.keys():
                 n_cp = len(surface['zshear_cp'])
                 # Add bspline components for active bspline geometric variables.
-                self.add_subsystem('zshear_bsp', BsplinesComp(
+                self.add_subsystem('zshear_bsp', om.BsplinesComp(
                     in_name='zshear_cp', out_name='zshear', units='m',
                     num_control_points=n_cp, num_points=int(ny),
                     bspline_order=min(n_cp, 4), distribution='uniform'),

--- a/openaerostruct/geometry/geometry_mesh.py
+++ b/openaerostruct/geometry/geometry_mesh.py
@@ -3,14 +3,14 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import Group
+import openmdao.api as om
 
 from openaerostruct.geometry.geometry_mesh_transformations import \
      Taper, ScaleX, Sweep, ShearX, Stretch, ShearY, Dihedral, \
      ShearZ, Rotate
 
 
-class GeometryMesh(Group):
+class GeometryMesh(om.Group):
     """
     OpenMDAO group that performs mesh manipulation functions. It reads in
     the initial mesh from the surface dictionary and outputs the altered

--- a/openaerostruct/geometry/geometry_mesh_transformations.py
+++ b/openaerostruct/geometry/geometry_mesh_transformations.py
@@ -5,10 +5,10 @@ from __future__ import division, print_function
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class Taper(ExplicitComponent):
+class Taper(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by altering the spanwise chord linearly to produce
     a tapered wing. Note that we apply taper around the quarter-chord line.
@@ -110,7 +110,7 @@ class Taper(ExplicitComponent):
         partials['mesh', 'taper'] = np.einsum('ijk, j->ijk', mesh - quarter_chord, dtaper)
 
 
-class ScaleX(ExplicitComponent):
+class ScaleX(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by modifying the chords along the span of the
     wing by scaling only the x-coord.
@@ -198,7 +198,7 @@ class ScaleX(ExplicitComponent):
         partials['mesh', 'in_mesh'][:nnq] += 0.75 * d_qc
 
 
-class Sweep(ExplicitComponent):
+class Sweep(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh applying shearing sweep. Positive sweeps back.
 
@@ -339,7 +339,7 @@ class Sweep(ExplicitComponent):
         partials['mesh', 'in_mesh'][nn + nn2:] = -tan_theta
 
 
-class ShearX(ExplicitComponent):
+class ShearX(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by shearing the wing in the x direction
     (distributed sweep).
@@ -394,7 +394,7 @@ class ShearX(ExplicitComponent):
         outputs['mesh'][:, :, 0] += inputs['xshear']
 
 
-class Stretch(ExplicitComponent):
+class Stretch(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by stretching the mesh in spanwise direction to
     reach specified span
@@ -539,7 +539,7 @@ class Stretch(ExplicitComponent):
         partials['mesh', 'in_mesh'][nn6:] = 0.25 * span / prev_span
 
 
-class ShearY(ExplicitComponent):
+class ShearY(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by shearing the wing in the y direction
     (distributed sweep).
@@ -594,7 +594,7 @@ class ShearY(ExplicitComponent):
         outputs['mesh'][:, :, 1] += inputs['yshear']
 
 
-class Dihedral(ExplicitComponent):
+class Dihedral(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by applying dihedral angle. Positive angles up.
 
@@ -733,7 +733,7 @@ class Dihedral(ExplicitComponent):
         partials['mesh', 'in_mesh'][nn + nn2:] = -tan_theta
 
 
-class ShearZ(ExplicitComponent):
+class ShearZ(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by shearing the wing in the z direction
     (distributed sweep).
@@ -788,7 +788,7 @@ class ShearZ(ExplicitComponent):
         outputs['mesh'][:, :, 2] += inputs['zshear']
 
 
-class Rotate(ExplicitComponent):
+class Rotate(om.ExplicitComponent):
     """
     OpenMDAO component that manipulates the mesh by compute rotation matrices given mesh and
     rotation angles in degrees.

--- a/openaerostruct/geometry/monotonic_constraint.py
+++ b/openaerostruct/geometry/monotonic_constraint.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MonotonicConstraint(ExplicitComponent):
+class MonotonicConstraint(om.ExplicitComponent):
     """
     Produce a constraint that is violated if a user-chosen measure on the
     wing does not decrease monotonically from the root to the tip.

--- a/openaerostruct/geometry/radius_comp.py
+++ b/openaerostruct/geometry/radius_comp.py
@@ -3,11 +3,11 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.structures.utils import radii
 
 
-class RadiusComp(ExplicitComponent):
+class RadiusComp(om.ExplicitComponent):
     """
     Compute the radius of a structural spar based on the mesh and thickness over
     chord ratio.

--- a/openaerostruct/geometry/tests/test_geometry_mesh.py
+++ b/openaerostruct/geometry/tests/test_geometry_mesh.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import unittest
 
-from openmdao.api import Problem, Group
+import openmdao.api as om
 
 from openaerostruct.geometry.geometry_mesh import GeometryMesh
 

--- a/openaerostruct/geometry/tests/test_geometry_mesh_transformations.py
+++ b/openaerostruct/geometry/tests/test_geometry_mesh_transformations.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import unittest
 
-from openmdao.api import Problem, Group
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 from openaerostruct.geometry.geometry_mesh_transformations import \
@@ -51,7 +51,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(1)
@@ -69,7 +69,7 @@ class Test(unittest.TestCase):
         symmetry = True
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(1)
@@ -87,7 +87,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(NY)
@@ -108,7 +108,7 @@ class Test(unittest.TestCase):
         symmetry = True
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(NY)
@@ -129,7 +129,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(1)
@@ -150,7 +150,7 @@ class Test(unittest.TestCase):
         symmetry = True
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(1)
@@ -171,7 +171,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(NY)
@@ -192,7 +192,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(1)
@@ -213,7 +213,7 @@ class Test(unittest.TestCase):
         symmetry = True
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(1)
@@ -234,7 +234,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(NY)
@@ -255,7 +255,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = 15.0*np.random.random(1)
@@ -276,7 +276,7 @@ class Test(unittest.TestCase):
         symmetry = True
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(1)
@@ -297,7 +297,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(NY)
@@ -318,7 +318,7 @@ class Test(unittest.TestCase):
         symmetry = False
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(NY)
@@ -339,7 +339,7 @@ class Test(unittest.TestCase):
         symmetry = True
         mesh = get_mesh(symmetry)
 
-        prob = Problem()
+        prob = om.Problem()
         group = prob.model
 
         val = np.random.random(NY)

--- a/openaerostruct/geometry/tests/test_radius_comp.py
+++ b/openaerostruct/geometry/tests/test_radius_comp.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 
 from openaerostruct.geometry.radius_comp import RadiusComp
 from openaerostruct.utils.testing import run_test, get_default_surfaces
@@ -15,12 +15,12 @@ class Test(unittest.TestCase):
     def test(self):
         surfaces = get_default_surfaces()
 
-        group = Group()
+        group = om.Group()
 
         comp = RadiusComp(surface=surfaces[0])
         ny = surfaces[0]['mesh'].shape[1]
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('mesh', val=surfaces[0]['mesh'], units='m')
         indep_var_comp.add_output('t_over_c', val=np.linspace(0.1,0.5,num=ny-1))
 

--- a/openaerostruct/integration/aerostruct_groups.py
+++ b/openaerostruct/integration/aerostruct_groups.py
@@ -247,7 +247,7 @@ class AerostructPoint(om.Group):
         coupled.nonlinear_solver.options['atol'] = 1e-7
         coupled.nonlinear_solver.options['rtol'] = 1e-30
         coupled.nonlinear_solver.options['iprint'] = 2
-        coupled.nonlinear_solver.options['err_on_maxiter'] = True
+        coupled.nonlinear_solver.options['err_on_non_converge'] = True
 
         # coupled.linear_solver = om.DirectSolver()
 

--- a/openaerostruct/integration/aerostruct_groups.py
+++ b/openaerostruct/integration/aerostruct_groups.py
@@ -12,10 +12,10 @@ from openaerostruct.aerodynamics.compressible_states import CompressibleVLMState
 from openaerostruct.structures.tube_group import TubeGroup
 from openaerostruct.structures.wingbox_group import WingboxGroup
 
-from openmdao.api import Group, NonlinearBlockGS, DirectSolver, LinearBlockGS, LinearRunOnce, NewtonSolver, ScipyKrylov
+import openmdao.api as om
 
 
-class AerostructGeometry(Group):
+class AerostructGeometry(om.Group):
 
     def initialize(self):
         self.options.declare('surface', types=dict)
@@ -85,7 +85,7 @@ class AerostructGeometry(Group):
             promotes_outputs=['nodes', 'local_stiff_transformed', 'structural_mass', 'cg_location', 'element_mass'])
 
 
-class CoupledAS(Group):
+class CoupledAS(om.Group):
 
     def initialize(self):
         self.options.declare('surface', types=dict)
@@ -114,10 +114,10 @@ class CoupledAS(Group):
             VLMGeometry(surface=surface),
             promotes_inputs=['def_mesh'], promotes_outputs=['b_pts', 'widths', 'cos_sweep', 'lengths', 'chords', 'normals', 'S_ref'])
 
-        self.linear_solver = LinearRunOnce()
+        self.linear_solver = om.LinearRunOnce()
 
 
-class CoupledPerformance(Group):
+class CoupledPerformance(om.Group):
 
     def initialize(self):
         self.options.declare('surface', types=dict)
@@ -142,7 +142,7 @@ class CoupledPerformance(Group):
             raise NameError('Please select a valid `fem_model_type` from either `tube` or `wingbox`.')
 
 
-class AerostructPoint(Group):
+class AerostructPoint(om.Group):
 
     def initialize(self):
         self.options.declare('surfaces', types=list)
@@ -158,7 +158,7 @@ class AerostructPoint(Group):
         surfaces = self.options['surfaces']
         rotational = self.options['rotational']
 
-        coupled = Group()
+        coupled = om.Group()
 
         for surface in surfaces:
 
@@ -240,21 +240,21 @@ class AerostructPoint(Group):
 
         # Set solver properties for the coupled group
         # coupled.linear_solver = ScipyKrylov()
-        # coupled.linear_solver.precon = LinearRunOnce()
+        # coupled.linear_solver.precon = om.LinearRunOnce()
 
-        coupled.nonlinear_solver = NonlinearBlockGS(use_aitken=True)
+        coupled.nonlinear_solver = om.NonlinearBlockGS(use_aitken=True)
         coupled.nonlinear_solver.options['maxiter'] = 100
         coupled.nonlinear_solver.options['atol'] = 1e-7
         coupled.nonlinear_solver.options['rtol'] = 1e-30
         coupled.nonlinear_solver.options['iprint'] = 2
         coupled.nonlinear_solver.options['err_on_maxiter'] = True
 
-        # coupled.linear_solver = DirectSolver()
+        # coupled.linear_solver = om.DirectSolver()
 
-        coupled.linear_solver = DirectSolver(assemble_jac=True)
+        coupled.linear_solver = om.DirectSolver(assemble_jac=True)
         coupled.options['assembled_jac_type'] = 'csc'
 
-        # coupled.nonlinear_solver = NewtonSolver(solve_subsystems=True)
+        # coupled.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
         # coupled.nonlinear_solver.options['maxiter'] = 50
 
         """

--- a/openaerostruct/integration/multipoint_comps.py
+++ b/openaerostruct/integration/multipoint_comps.py
@@ -1,7 +1,7 @@
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MultiCD(ExplicitComponent):
+class MultiCD(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('n_points', types=int)

--- a/openaerostruct/structures/assemble_k_group.py
+++ b/openaerostruct/structures/assemble_k_group.py
@@ -1,11 +1,11 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.structures.transform import Transform
 from openaerostruct.structures.length import Length
 from openaerostruct.structures.local_stiff import LocalStiff
 from openaerostruct.structures.local_stiff_permuted import LocalStiffPermuted
 from openaerostruct.structures.local_stiff_transformed import LocalStiffTransformed
 
-class AssembleKGroup(Group):
+class AssembleKGroup(om.Group):
     """ Assemble that there compact local stiffness matrix. """
 
     def initialize(self):

--- a/openaerostruct/structures/compute_nodes.py
+++ b/openaerostruct/structures/compute_nodes.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ComputeNodes(ExplicitComponent):
+class ComputeNodes(om.ExplicitComponent):
     """
     Compute FEM nodes based on aerodynamic mesh.
 

--- a/openaerostruct/structures/compute_point_mass_loads.py
+++ b/openaerostruct/structures/compute_point_mass_loads.py
@@ -1,12 +1,12 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.structures.utils import norm
 from openaerostruct.utils.constants import grav_constant
 
 
-class ComputePointMassLoads(ExplicitComponent):
+class ComputePointMassLoads(om.ExplicitComponent):
     """
     Compute the loads on the structure due to point masses.
     The current method adds loads and moments to all of the structural nodes, but

--- a/openaerostruct/structures/compute_thrust_loads.py
+++ b/openaerostruct/structures/compute_thrust_loads.py
@@ -1,12 +1,12 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.structures.utils import norm
 from openaerostruct.utils.constants import grav_constant
 
 
-class ComputeThrustLoads(ExplicitComponent):
+class ComputeThrustLoads(om.ExplicitComponent):
     """
     Compute the loads on the structure due to the thrust of engines.
     The current method adds loads and moments to all of the structural nodes, but

--- a/openaerostruct/structures/create_rhs.py
+++ b/openaerostruct/structures/create_rhs.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class CreateRHS(ExplicitComponent):
+class CreateRHS(om.ExplicitComponent):
     """
     Compute the right-hand-side of the K * u = f linear system to solve for the displacements.
     The RHS is based on the loads. For the aerostructural case, these are

--- a/openaerostruct/structures/disp.py
+++ b/openaerostruct/structures/disp.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class Disp(ExplicitComponent):
+class Disp(om.ExplicitComponent):
     """
     Reshape the flattened displacements from the linear system solution into
     a 2D array so we can more easily use the results.

--- a/openaerostruct/structures/energy.py
+++ b/openaerostruct/structures/energy.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class Energy(ExplicitComponent):
+class Energy(om.ExplicitComponent):
     """ Compute strain energy.
 
     Parameters

--- a/openaerostruct/structures/failure_exact.py
+++ b/openaerostruct/structures/failure_exact.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class FailureExact(ExplicitComponent):
+class FailureExact(om.ExplicitComponent):
     """
     Output individual failure constraints on each FEM element.
 

--- a/openaerostruct/structures/failure_ks.py
+++ b/openaerostruct/structures/failure_ks.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class FailureKS(ExplicitComponent):
+class FailureKS(om.ExplicitComponent):
     """
     Aggregate failure constraints from the structure.
 

--- a/openaerostruct/structures/fem.py
+++ b/openaerostruct/structures/fem.py
@@ -7,10 +7,10 @@ import numpy as np
 from scipy.sparse import coo_matrix
 from scipy.sparse.linalg import splu
 
-from openmdao.core.implicitcomponent import ImplicitComponent
+import openmdao.api as om
 
 
-class FEM(ImplicitComponent):
+class FEM(om.ImplicitComponent):
     """
     Component that solves a linear system, Ax=b.
 

--- a/openaerostruct/structures/fuel_loads.py
+++ b/openaerostruct/structures/fuel_loads.py
@@ -1,14 +1,14 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
 def norm(vec):
     return np.sqrt(np.sum(vec**2))
 
-class FuelLoads(ExplicitComponent):
+class FuelLoads(om.ExplicitComponent):
     """
     Compute the nodal loads from the distributed fuel within the wing
     to be applied to the wing structure.

--- a/openaerostruct/structures/fuel_vol.py
+++ b/openaerostruct/structures/fuel_vol.py
@@ -1,13 +1,13 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
 def norm(vec):
     return np.sqrt(np.sum(vec**2))
 
-class WingboxFuelVol(ExplicitComponent):
+class WingboxFuelVol(om.ExplicitComponent):
     """
     Computes the internal volumes of the wingbox segments.
 

--- a/openaerostruct/structures/length.py
+++ b/openaerostruct/structures/length.py
@@ -1,12 +1,12 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.utils.vector_algebra import compute_norm
 
 
-class Length(ExplicitComponent):
+class Length(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('surface', types=dict)

--- a/openaerostruct/structures/local_stiff.py
+++ b/openaerostruct/structures/local_stiff.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
 coeffs_2 = np.array([
@@ -24,7 +24,7 @@ coeffs_z = np.array([
 ])
 
 
-class LocalStiff(ExplicitComponent):
+class LocalStiff(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('surface', types=dict)

--- a/openaerostruct/structures/local_stiff_permuted.py
+++ b/openaerostruct/structures/local_stiff_permuted.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
 row_indices = np.arange(12)
@@ -15,7 +15,7 @@ mtx = np.zeros((12, 12))
 mtx[row_indices, col_indices] = 1.
 
 
-class LocalStiffPermuted(ExplicitComponent):
+class LocalStiffPermuted(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('surface', types=dict)

--- a/openaerostruct/structures/local_stiff_transformed.py
+++ b/openaerostruct/structures/local_stiff_transformed.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class LocalStiffTransformed(ExplicitComponent):
+class LocalStiffTransformed(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('surface', types=dict)

--- a/openaerostruct/structures/non_intersecting_thickness.py
+++ b/openaerostruct/structures/non_intersecting_thickness.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class NonIntersectingThickness(ExplicitComponent):
+class NonIntersectingThickness(om.ExplicitComponent):
     """
     Create a constraint so the thickness of the spar does not intersect
     itself in the center of the spar. Basically, the thickness must be less

--- a/openaerostruct/structures/section_properties_tube.py
+++ b/openaerostruct/structures/section_properties_tube.py
@@ -1,9 +1,9 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class SectionPropertiesTube(ExplicitComponent):
+class SectionPropertiesTube(om.ExplicitComponent):
     """
     Compute geometric properties for a tube element.
     The thicknesses are added to the interior of the element, so the

--- a/openaerostruct/structures/section_properties_wingbox.py
+++ b/openaerostruct/structures/section_properties_wingbox.py
@@ -1,10 +1,10 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class SectionPropertiesWingbox(ExplicitComponent):
+class SectionPropertiesWingbox(om.ExplicitComponent):
     """
     Compute geometric cross-section properties for the wingbox elements.
     See Chauhan et al. (https://doi.org/10.1007/978-3-319-97773-7_38) for more.

--- a/openaerostruct/structures/spar_within_wing.py
+++ b/openaerostruct/structures/spar_within_wing.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.structures.utils import radii
 
 
-class SparWithinWing(ExplicitComponent):
+class SparWithinWing(om.ExplicitComponent):
     """
     Create a constraint to see if the spar is within the wing.
     This is based on the wing's t/c and the spar radius.

--- a/openaerostruct/structures/spatial_beam_functionals.py
+++ b/openaerostruct/structures/spatial_beam_functionals.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group
+import openmdao.api as om
 # from openaerostruct.structures.energy import Energy
 # from openaerostruct.structures.weight import Weight
 # from openaerostruct.structures.spar_within_wing import SparWithinWing
@@ -8,7 +8,7 @@ from openaerostruct.structures.non_intersecting_thickness import NonIntersecting
 from openaerostruct.structures.failure_exact import FailureExact
 from openaerostruct.structures.failure_ks import FailureKS
 
-class SpatialBeamFunctionals(Group):
+class SpatialBeamFunctionals(om.Group):
     """ Group that contains the spatial beam functionals used to evaluate
     performance. """
 

--- a/openaerostruct/structures/spatial_beam_setup.py
+++ b/openaerostruct/structures/spatial_beam_setup.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.structures.compute_nodes import ComputeNodes
 from openaerostruct.structures.assemble_k_group import AssembleKGroup
 from openaerostruct.structures.weight import Weight
@@ -6,7 +6,7 @@ from openaerostruct.structures.structural_cg import StructuralCG
 from openaerostruct.structures.fuel_vol import WingboxFuelVol
 
 
-class SpatialBeamSetup(Group):
+class SpatialBeamSetup(om.Group):
     """ Group that sets up the spatial beam components and assembles the
         stiffness matrix."""
 

--- a/openaerostruct/structures/spatial_beam_states.py
+++ b/openaerostruct/structures/spatial_beam_states.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.structures.create_rhs import CreateRHS
 from openaerostruct.structures.fem import FEM
 from openaerostruct.structures.disp import Disp
@@ -8,7 +8,7 @@ from openaerostruct.structures.total_loads import TotalLoads
 from openaerostruct.structures.compute_point_mass_loads import ComputePointMassLoads
 from openaerostruct.structures.compute_thrust_loads import ComputeThrustLoads
 
-class SpatialBeamStates(Group):
+class SpatialBeamStates(om.Group):
     """ Group that contains the spatial beam states. """
 
     def initialize(self):

--- a/openaerostruct/structures/struct_groups.py
+++ b/openaerostruct/structures/struct_groups.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.structures.spatial_beam_states import SpatialBeamStates
 from openaerostruct.structures.spatial_beam_functionals import SpatialBeamFunctionals
@@ -7,7 +7,7 @@ from openaerostruct.structures.tube_group import TubeGroup
 from openaerostruct.structures.wingbox_group import WingboxGroup
 
 
-class SpatialBeamAlone(Group):
+class SpatialBeamAlone(om.Group):
     """ Group that contains everything needed for a structural-only problem. """
 
     def initialize(self):

--- a/openaerostruct/structures/structural_cg.py
+++ b/openaerostruct/structures/structural_cg.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class StructuralCG(ExplicitComponent):
+class StructuralCG(om.ExplicitComponent):
     """ Compute center-of-gravity location of the spar elements.
 
     parameters

--- a/openaerostruct/structures/tests/test_add_point_masses.py
+++ b/openaerostruct/structures/tests/test_add_point_masses.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 
 from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from openaerostruct.structures.compute_point_mass_loads import ComputePointMassLoads
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -19,9 +19,9 @@ class Test(unittest.TestCase):
 
         comp = ComputePointMassLoads(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 
@@ -52,9 +52,9 @@ class Test(unittest.TestCase):
 
         comp = ComputePointMassLoads(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/structures/tests/test_fuel_loads.py
+++ b/openaerostruct/structures/tests/test_fuel_loads.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.api import Group, IndepVarComp, Problem
+import openmdao.api as om
 from openaerostruct.structures.fuel_loads import FuelLoads
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 import numpy as np
@@ -12,9 +12,9 @@ class Test(unittest.TestCase):
 
         comp = FuelLoads(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/structures/tests/test_materials_wingbox.py
+++ b/openaerostruct/structures/tests/test_materials_wingbox.py
@@ -64,42 +64,19 @@ class Test(unittest.TestCase):
         indep_var_comp.add_output('streamwise_chords_cp', val=surface['streamwise_chords_cp'])
         indep_var_comp.add_output('fem_twists_cp', val=surface['fem_twists_cp'])
         prob.model.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
-
-        prob.model.add_subsystem('t_over_c_bsp', om.BsplinesComp(
-            in_name='t_over_c_cp', out_name='t_over_c',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
-
-        prob.model.add_subsystem('skin_thickness_bsp', om.BsplinesComp(
-            in_name='skin_thickness_cp', out_name='skin_thickness',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['skin_thickness_cp'], promotes_outputs=['skin_thickness'])
-
-        prob.model.add_subsystem('spar_thickness_bsp', om.BsplinesComp(
-            in_name='spar_thickness_cp', out_name='spar_thickness',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['spar_thickness_cp'], promotes_outputs=['spar_thickness'])
-
-        prob.model.add_subsystem('fem_chords_bsp', om.BsplinesComp(
-            in_name='fem_chords_cp', out_name='fem_chords',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['fem_chords_cp'], promotes_outputs=['fem_chords'])
-
-        prob.model.add_subsystem('streamwise_chords_bsp', om.BsplinesComp(
-            in_name='streamwise_chords_cp', out_name='streamwise_chords',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['streamwise_chords_cp'], promotes_outputs=['streamwise_chords'])
-
-        prob.model.add_subsystem('fem_twists_bsp', om.BsplinesComp(
-            in_name='fem_twists_cp', out_name='fem_twists',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['fem_twists_cp'], promotes_outputs=['fem_twists'])
+        
+        x_interp = np.linspace(0., 1., int(ny-1))
+        comp = prob.model.add_subsystem('bsplines_comp', om.SplineComp(
+            method='bsplines', x_interp_val=x_interp,
+            num_cp=n_cp,
+            interp_options={'order' : min(n_cp, 4)}),
+            promotes_inputs=['*'], promotes_outputs=['*'])
+        comp.add_spline(y_cp_name='t_over_c_cp', y_interp_name='t_over_c')
+        comp.add_spline(y_cp_name='skin_thickness_cp', y_interp_name='skin_thickness', y_units='m')
+        comp.add_spline(y_cp_name='spar_thickness_cp', y_interp_name='spar_thickness', y_units='m')
+        comp.add_spline(y_cp_name='fem_chords_cp', y_interp_name='fem_chords', y_units='m')
+        comp.add_spline(y_cp_name='streamwise_chords_cp', y_interp_name='streamwise_chords', y_units='m')
+        comp.add_spline(y_cp_name='fem_twists_cp', y_interp_name='fem_twists', y_units='deg')
 
         comp = SectionPropertiesWingbox(surface=surface)
         prob.model.add_subsystem('sec_prop_wb', comp, promotes=['*'])
@@ -170,42 +147,19 @@ class Test(unittest.TestCase):
         indep_var_comp.add_output('streamwise_chords_cp', val=surface['streamwise_chords_cp'])
         indep_var_comp.add_output('fem_twists_cp', val=surface['fem_twists_cp'])
         prob.model.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
-
-        prob.model.add_subsystem('t_over_c_bsp', om.BsplinesComp(
-            in_name='t_over_c_cp', out_name='t_over_c',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
-
-        prob.model.add_subsystem('skin_thickness_bsp', om.BsplinesComp(
-            in_name='skin_thickness_cp', out_name='skin_thickness',
-            num_control_points=n_cp, num_points=int(ny-1), units='m',
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['skin_thickness_cp'], promotes_outputs=['skin_thickness'])
-
-        prob.model.add_subsystem('spar_thickness_bsp', om.BsplinesComp(
-            in_name='spar_thickness_cp', out_name='spar_thickness',
-            num_control_points=n_cp, num_points=int(ny-1), units='m',
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['spar_thickness_cp'], promotes_outputs=['spar_thickness'])
-
-        prob.model.add_subsystem('fem_chords_bsp', om.BsplinesComp(
-            in_name='fem_chords_cp', out_name='fem_chords',
-            num_control_points=n_cp, num_points=int(ny-1), units='m',
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['fem_chords_cp'], promotes_outputs=['fem_chords'])
-
-        prob.model.add_subsystem('streamwise_chords_bsp', om.BsplinesComp(
-            in_name='streamwise_chords_cp', out_name='streamwise_chords',
-            num_control_points=n_cp, num_points=int(ny-1), units='m',
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['streamwise_chords_cp'], promotes_outputs=['streamwise_chords'])
-
-        prob.model.add_subsystem('fem_twists_bsp', om.BsplinesComp(
-            in_name='fem_twists_cp', out_name='fem_twists', units='deg',
-            num_control_points=n_cp, num_points=int(ny-1),
-            bspline_order=min(n_cp, 4), distribution='uniform'),
-            promotes_inputs=['fem_twists_cp'], promotes_outputs=['fem_twists'])
+        
+        x_interp = np.linspace(0., 1., int(ny-1))
+        comp = prob.model.add_subsystem('bsplines_comp', om.SplineComp(
+            method='bsplines', x_interp_val=x_interp,
+            num_cp=n_cp,
+            interp_options={'order' : min(n_cp, 4)}),
+            promotes_inputs=['*'], promotes_outputs=['*'])
+        comp.add_spline(y_cp_name='t_over_c_cp', y_interp_name='t_over_c')
+        comp.add_spline(y_cp_name='skin_thickness_cp', y_interp_name='skin_thickness', y_units='m')
+        comp.add_spline(y_cp_name='spar_thickness_cp', y_interp_name='spar_thickness', y_units='m')
+        comp.add_spline(y_cp_name='fem_chords_cp', y_interp_name='fem_chords', y_units='m')
+        comp.add_spline(y_cp_name='streamwise_chords_cp', y_interp_name='streamwise_chords', y_units='m')
+        comp.add_spline(y_cp_name='fem_twists_cp', y_interp_name='fem_twists', y_units='deg')
 
         comp = SectionPropertiesWingbox(surface=surface)
         prob.model.add_subsystem('sec_prop_wb', comp, promotes=['*'])

--- a/openaerostruct/structures/tests/test_materials_wingbox.py
+++ b/openaerostruct/structures/tests/test_materials_wingbox.py
@@ -3,7 +3,7 @@ import numpy as np
 from openaerostruct.structures.section_properties_wingbox import SectionPropertiesWingbox
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.api import Problem, IndepVarComp, BsplinesComp
+import openmdao.api as om
 
 class Test(unittest.TestCase):
 
@@ -54,9 +54,9 @@ class Test(unittest.TestCase):
         nx = mesh.shape[0]
         n_cp = len(surface['t_over_c_cp'])
 
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
         indep_var_comp.add_output('spar_thickness_cp', val=surface['spar_thickness_cp'])
         indep_var_comp.add_output('skin_thickness_cp', val=surface['skin_thickness_cp'])
@@ -65,37 +65,37 @@ class Test(unittest.TestCase):
         indep_var_comp.add_output('fem_twists_cp', val=surface['fem_twists_cp'])
         prob.model.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
 
-        prob.model.add_subsystem('t_over_c_bsp', BsplinesComp(
+        prob.model.add_subsystem('t_over_c_bsp', om.BsplinesComp(
             in_name='t_over_c_cp', out_name='t_over_c',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
 
-        prob.model.add_subsystem('skin_thickness_bsp', BsplinesComp(
+        prob.model.add_subsystem('skin_thickness_bsp', om.BsplinesComp(
             in_name='skin_thickness_cp', out_name='skin_thickness',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['skin_thickness_cp'], promotes_outputs=['skin_thickness'])
 
-        prob.model.add_subsystem('spar_thickness_bsp', BsplinesComp(
+        prob.model.add_subsystem('spar_thickness_bsp', om.BsplinesComp(
             in_name='spar_thickness_cp', out_name='spar_thickness',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['spar_thickness_cp'], promotes_outputs=['spar_thickness'])
 
-        prob.model.add_subsystem('fem_chords_bsp', BsplinesComp(
+        prob.model.add_subsystem('fem_chords_bsp', om.BsplinesComp(
             in_name='fem_chords_cp', out_name='fem_chords',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['fem_chords_cp'], promotes_outputs=['fem_chords'])
 
-        prob.model.add_subsystem('streamwise_chords_bsp', BsplinesComp(
+        prob.model.add_subsystem('streamwise_chords_bsp', om.BsplinesComp(
             in_name='streamwise_chords_cp', out_name='streamwise_chords',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['streamwise_chords_cp'], promotes_outputs=['streamwise_chords'])
 
-        prob.model.add_subsystem('fem_twists_bsp', BsplinesComp(
+        prob.model.add_subsystem('fem_twists_bsp', om.BsplinesComp(
             in_name='fem_twists_cp', out_name='fem_twists',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -106,9 +106,7 @@ class Test(unittest.TestCase):
 
 
         prob.setup()
-        #
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 
@@ -162,9 +160,9 @@ class Test(unittest.TestCase):
         nx = mesh.shape[0]
         n_cp = len(surface['t_over_c_cp'])
 
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=surface['t_over_c_cp'])
         indep_var_comp.add_output('spar_thickness_cp', val=surface['spar_thickness_cp'])
         indep_var_comp.add_output('skin_thickness_cp', val=surface['skin_thickness_cp'])
@@ -173,37 +171,37 @@ class Test(unittest.TestCase):
         indep_var_comp.add_output('fem_twists_cp', val=surface['fem_twists_cp'])
         prob.model.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
 
-        prob.model.add_subsystem('t_over_c_bsp', BsplinesComp(
+        prob.model.add_subsystem('t_over_c_bsp', om.BsplinesComp(
             in_name='t_over_c_cp', out_name='t_over_c',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['t_over_c_cp'], promotes_outputs=['t_over_c'])
 
-        prob.model.add_subsystem('skin_thickness_bsp', BsplinesComp(
+        prob.model.add_subsystem('skin_thickness_bsp', om.BsplinesComp(
             in_name='skin_thickness_cp', out_name='skin_thickness',
             num_control_points=n_cp, num_points=int(ny-1), units='m',
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['skin_thickness_cp'], promotes_outputs=['skin_thickness'])
 
-        prob.model.add_subsystem('spar_thickness_bsp', BsplinesComp(
+        prob.model.add_subsystem('spar_thickness_bsp', om.BsplinesComp(
             in_name='spar_thickness_cp', out_name='spar_thickness',
             num_control_points=n_cp, num_points=int(ny-1), units='m',
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['spar_thickness_cp'], promotes_outputs=['spar_thickness'])
 
-        prob.model.add_subsystem('fem_chords_bsp', BsplinesComp(
+        prob.model.add_subsystem('fem_chords_bsp', om.BsplinesComp(
             in_name='fem_chords_cp', out_name='fem_chords',
             num_control_points=n_cp, num_points=int(ny-1), units='m',
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['fem_chords_cp'], promotes_outputs=['fem_chords'])
 
-        prob.model.add_subsystem('streamwise_chords_bsp', BsplinesComp(
+        prob.model.add_subsystem('streamwise_chords_bsp', om.BsplinesComp(
             in_name='streamwise_chords_cp', out_name='streamwise_chords',
             num_control_points=n_cp, num_points=int(ny-1), units='m',
             bspline_order=min(n_cp, 4), distribution='uniform'),
             promotes_inputs=['streamwise_chords_cp'], promotes_outputs=['streamwise_chords'])
 
-        prob.model.add_subsystem('fem_twists_bsp', BsplinesComp(
+        prob.model.add_subsystem('fem_twists_bsp', om.BsplinesComp(
             in_name='fem_twists_cp', out_name='fem_twists', units='deg',
             num_control_points=n_cp, num_points=int(ny-1),
             bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -214,9 +212,7 @@ class Test(unittest.TestCase):
 
 
         prob.setup()
-        #
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/structures/tests/test_structural_cg.py
+++ b/openaerostruct/structures/tests/test_structural_cg.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from openaerostruct.structures.structural_cg import StructuralCG
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -12,11 +12,11 @@ class Test(unittest.TestCase):
     def test(self):
         surface = get_default_surfaces()[0]
 
-        group = Group()
+        group = om.Group()
 
         comp = StructuralCG(surface=surface)
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/structures/tests/test_thrust_loads.py
+++ b/openaerostruct/structures/tests/test_thrust_loads.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 
 from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.api import Group, IndepVarComp, Problem
+import openmdao.api as om
 from openaerostruct.structures.compute_thrust_loads import ComputeThrustLoads
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -18,9 +18,9 @@ class Test(unittest.TestCase):
 
         comp = ComputeThrustLoads(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 
@@ -40,7 +40,7 @@ class Test(unittest.TestCase):
         group.add_subsystem('indep_var_comp', indep_var_comp, promotes=['*'])
         group.add_subsystem('compute_point_mass_loads', comp, promotes=['*'])
 
-        prob = Problem(model=group)
+        prob = om.Problem(model=group)
         prob.setup()
         prob.run_model()
 
@@ -57,9 +57,9 @@ class Test(unittest.TestCase):
 
         comp = ComputeThrustLoads(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 
@@ -90,9 +90,9 @@ class Test(unittest.TestCase):
 
         comp = ComputeThrustLoads(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/structures/tests/test_total_load_derivs.py
+++ b/openaerostruct/structures/tests/test_total_load_derivs.py
@@ -3,7 +3,7 @@ import unittest
 from openaerostruct.structures.wing_weight_loads import StructureWeightLoads
 from openaerostruct.structures.total_loads import TotalLoads
 from openaerostruct.utils.testing import run_test, get_default_surfaces
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 import numpy as np
 
 class Test(unittest.TestCase):
@@ -36,9 +36,9 @@ class Test(unittest.TestCase):
 
         comp = StructureWeightLoads(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/structures/tests/test_vonmises_tube.py
+++ b/openaerostruct/structures/tests/test_vonmises_tube.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from openaerostruct.structures.vonmises_tube import VonMisesTube
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -11,11 +11,11 @@ class Test(unittest.TestCase):
     def test(self):
         surface = get_default_surfaces()[0]
 
-        group = Group()
+        group = om.Group()
 
         comp = VonMisesTube(surface=surface)
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/structures/tests/test_vonmises_wingbox.py
+++ b/openaerostruct/structures/tests/test_vonmises_wingbox.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from openaerostruct.structures.vonmises_wingbox import VonMisesWingbox
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -19,9 +19,9 @@ class Test(unittest.TestCase):
 
         comp = VonMisesWingbox(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/structures/tests/test_weight.py
+++ b/openaerostruct/structures/tests/test_weight.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from openaerostruct.structures.weight import Weight
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -14,9 +14,9 @@ class Test(unittest.TestCase):
         surface = get_default_surfaces()[0]
         ny = surface['mesh'].shape[1]
 
-        group = Group()
+        group = om.Group()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output('nodes', val=np.random.random_sample((ny, 3)))
 
         comp = Weight(surface=surface)

--- a/openaerostruct/structures/tests/test_wingbox_geometry.py
+++ b/openaerostruct/structures/tests/test_wingbox_geometry.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from openaerostruct.structures.wingbox_geometry import WingboxGeometry
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -19,9 +19,9 @@ class Test(unittest.TestCase):
 
         comp = WingboxGeometry(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         indep_var_comp.add_output('mesh', val=surface['mesh'])
 

--- a/openaerostruct/structures/total_loads.py
+++ b/openaerostruct/structures/total_loads.py
@@ -1,10 +1,10 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class TotalLoads(ExplicitComponent):
+class TotalLoads(om.ExplicitComponent):
     """
     Add the loads from the aerodynamics, structural weight, and fuel weight.
 

--- a/openaerostruct/structures/transform.py
+++ b/openaerostruct/structures/transform.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.utils.vector_algebra import add_ones_axis
 from openaerostruct.utils.vector_algebra import compute_norm, compute_norm_deriv
 from openaerostruct.utils.vector_algebra import compute_cross, compute_cross_deriv1, compute_cross_deriv2
 
 
-class Transform(ExplicitComponent):
+class Transform(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('surface', types=dict)

--- a/openaerostruct/structures/tube_group.py
+++ b/openaerostruct/structures/tube_group.py
@@ -1,11 +1,9 @@
-from openmdao.api import Group, BsplinesComp
+import openmdao.api as om
 from openaerostruct.structures.section_properties_tube import SectionPropertiesTube
 from openaerostruct.geometry.radius_comp import RadiusComp
 
-from openmdao.api import IndepVarComp, Group
 
-
-class TubeGroup(Group):
+class TubeGroup(om.Group):
     """ Group that contains everything needed for a structural-only problem. """
 
     def initialize(self):
@@ -20,7 +18,7 @@ class TubeGroup(Group):
 
         if connect_geom_DVs:
             # Add independent variables that do not belong to a specific component
-            indep_var_comp = IndepVarComp()
+            indep_var_comp = om.IndepVarComp()
 
             # Add structural components to the surface-specific group
             self.add_subsystem('indep_vars',
@@ -30,7 +28,7 @@ class TubeGroup(Group):
         if 'thickness_cp' in surface.keys():
             n_cp = len(surface['thickness_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('thickness_bsp', BsplinesComp(
+            self.add_subsystem('thickness_bsp', om.BsplinesComp(
                 in_name='thickness_cp', out_name='thickness', units='m',
                 num_control_points=n_cp, num_points=int(ny-1),
                 bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -41,7 +39,7 @@ class TubeGroup(Group):
         if 'radius_cp' in surface.keys():
             n_cp = len(surface['radius_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('radius_bsp', BsplinesComp(
+            self.add_subsystem('radius_bsp', om.BsplinesComp(
                 in_name='radius_cp', out_name='radius', units='m',
                 num_control_points=n_cp, num_points=int(ny-1),
                 bspline_order=min(n_cp, 4), distribution='uniform'),

--- a/openaerostruct/structures/tube_group.py
+++ b/openaerostruct/structures/tube_group.py
@@ -1,3 +1,4 @@
+import numpy as np
 import openmdao.api as om
 from openaerostruct.structures.section_properties_tube import SectionPropertiesTube
 from openaerostruct.geometry.radius_comp import RadiusComp
@@ -28,22 +29,26 @@ class TubeGroup(om.Group):
         if 'thickness_cp' in surface.keys():
             n_cp = len(surface['thickness_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('thickness_bsp', om.BsplinesComp(
-                in_name='thickness_cp', out_name='thickness', units='m',
-                num_control_points=n_cp, num_points=int(ny-1),
-                bspline_order=min(n_cp, 4), distribution='uniform'),
+            x_interp = np.linspace(0., 1., int(ny-1))
+            comp = self.add_subsystem('thickness_bsp', om.SplineComp(
+                method='bsplines', x_interp_val=x_interp,
+                num_cp=n_cp,
+                interp_options={'order' : min(n_cp, 4)}),
                 promotes_inputs=['thickness_cp'], promotes_outputs=['thickness'])
+            comp.add_spline(y_cp_name='thickness_cp', y_interp_name='thickness')
             if connect_geom_DVs:
                 indep_var_comp.add_output('thickness_cp', val=surface['thickness_cp'], units='m')
 
         if 'radius_cp' in surface.keys():
             n_cp = len(surface['radius_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('radius_bsp', om.BsplinesComp(
-                in_name='radius_cp', out_name='radius', units='m',
-                num_control_points=n_cp, num_points=int(ny-1),
-                bspline_order=min(n_cp, 4), distribution='uniform'),
+            x_interp = np.linspace(0., 1., int(ny-1))
+            comp = self.add_subsystem('radius_bsp', om.SplineComp(
+                method='bsplines', x_interp_val=x_interp,
+                num_cp=n_cp,
+                interp_options={'order' : min(n_cp, 4)}),
                 promotes_inputs=['radius_cp'], promotes_outputs=['radius'])
+            comp.add_spline(y_cp_name='radius_cp', y_interp_name='radius')
             if connect_geom_DVs:
                 indep_var_comp.add_output('radius_cp', val=surface['radius_cp'], units='m')
         else:

--- a/openaerostruct/structures/vonmises_tube.py
+++ b/openaerostruct/structures/vonmises_tube.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.structures.utils import norm, unit, norm_d, unit_d, cross_d
 
-class VonMisesTube(ExplicitComponent):
+class VonMisesTube(om.ExplicitComponent):
     """ Compute the von Mises stress in each element.
 
     parameters

--- a/openaerostruct/structures/vonmises_wingbox.py
+++ b/openaerostruct/structures/vonmises_wingbox.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.structures.utils import norm, unit
 
 
-class VonMisesWingbox(ExplicitComponent):
+class VonMisesWingbox(om.ExplicitComponent):
     """ Compute the von Mises stresses for each element.
     See Chauhan et al. (https://doi.org/10.1007/978-3-319-97773-7_38) for more.
 

--- a/openaerostruct/structures/weight.py
+++ b/openaerostruct/structures/weight.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.structures.utils import norm
 
 
-class Weight(ExplicitComponent):
+class Weight(om.ExplicitComponent):
     """ Compute total weight and center-of-gravity location of the spar elements.
 
     parameters

--- a/openaerostruct/structures/wing_weight_loads.py
+++ b/openaerostruct/structures/wing_weight_loads.py
@@ -3,12 +3,12 @@ import numpy as np
 
 from scipy.sparse import coo_matrix, diags
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.structures.utils import norm
 from openaerostruct.utils.constants import grav_constant
 
 
-class StructureWeightLoads(ExplicitComponent):
+class StructureWeightLoads(om.ExplicitComponent):
     """
     Compute the nodal loads from the weight of the wing structure to be applied to the wing
     structure.

--- a/openaerostruct/structures/wingbox_fuel_vol_delta.py
+++ b/openaerostruct/structures/wingbox_fuel_vol_delta.py
@@ -1,13 +1,13 @@
 from __future__ import print_function, division
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
 def norm(vec):
     return np.sqrt(np.sum(vec**2))
 
-class WingboxFuelVolDelta(ExplicitComponent):
+class WingboxFuelVolDelta(om.ExplicitComponent):
     """
     Create a constraint to ensure the wingbox has enough internal volume to 
     store the required fuel.

--- a/openaerostruct/structures/wingbox_geometry.py
+++ b/openaerostruct/structures/wingbox_geometry.py
@@ -1,10 +1,10 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from openaerostruct.structures.utils import norm
 
-class WingboxGeometry(ExplicitComponent):
+class WingboxGeometry(om.ExplicitComponent):
     """
     Compute effective chord lengths and twists normal to the wingbox elements.
 

--- a/openaerostruct/structures/wingbox_group.py
+++ b/openaerostruct/structures/wingbox_group.py
@@ -1,11 +1,9 @@
-from openmdao.api import Group, BsplinesComp
+import openmdao.api as om
 from openaerostruct.structures.section_properties_wingbox import SectionPropertiesWingbox
 from openaerostruct.structures.wingbox_geometry import WingboxGeometry
 
-from openmdao.api import IndepVarComp, Group
 
-
-class WingboxGroup(Group):
+class WingboxGroup(om.Group):
     """ Group that contains everything needed for a structural-only problem. """
 
     def initialize(self):
@@ -17,7 +15,7 @@ class WingboxGroup(Group):
 
         if 'spar_thickness_cp' in surface.keys() or 'skin_thickness_cp' in surface.keys():
             # Add independent variables that do not belong to a specific component
-            indep_var_comp = IndepVarComp()
+            indep_var_comp = om.IndepVarComp()
 
             # Add structural components to the surface-specific group
             self.add_subsystem('indep_vars',
@@ -27,7 +25,7 @@ class WingboxGroup(Group):
         if 'spar_thickness_cp' in surface.keys():
             n_cp = len(surface['spar_thickness_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('spar_thickness_bsp', BsplinesComp(
+            self.add_subsystem('spar_thickness_bsp', om.BsplinesComp(
                 in_name='spar_thickness_cp', out_name='spar_thickness',
                 num_control_points=n_cp, num_points=int(ny-1), units='m',
                 bspline_order=min(n_cp, 4), distribution='uniform'),
@@ -37,7 +35,7 @@ class WingboxGroup(Group):
         if 'skin_thickness_cp' in surface.keys():
             n_cp = len(surface['skin_thickness_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('skin_thickness_bsp', BsplinesComp(
+            self.add_subsystem('skin_thickness_bsp', om.BsplinesComp(
                 in_name='skin_thickness_cp', out_name='skin_thickness',
                 num_control_points=n_cp, num_points=int(ny-1), units='m',
                 bspline_order=min(n_cp, 4), distribution='uniform'),

--- a/openaerostruct/structures/wingbox_group.py
+++ b/openaerostruct/structures/wingbox_group.py
@@ -1,3 +1,4 @@
+import numpy as np
 import openmdao.api as om
 from openaerostruct.structures.section_properties_wingbox import SectionPropertiesWingbox
 from openaerostruct.structures.wingbox_geometry import WingboxGeometry
@@ -25,21 +26,25 @@ class WingboxGroup(om.Group):
         if 'spar_thickness_cp' in surface.keys():
             n_cp = len(surface['spar_thickness_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('spar_thickness_bsp', om.BsplinesComp(
-                in_name='spar_thickness_cp', out_name='spar_thickness',
-                num_control_points=n_cp, num_points=int(ny-1), units='m',
-                bspline_order=min(n_cp, 4), distribution='uniform'),
+            x_interp = np.linspace(0., 1., int(ny-1))
+            comp = self.add_subsystem('spar_thickness_bsp', om.SplineComp(
+                method='bsplines', x_interp_val=x_interp,
+                num_cp=n_cp,
+                interp_options={'order' : min(n_cp, 4)}),
                 promotes_inputs=['spar_thickness_cp'], promotes_outputs=['spar_thickness'])
+            comp.add_spline(y_cp_name='spar_thickness_cp', y_interp_name='spar_thickness')
             indep_var_comp.add_output('spar_thickness_cp', val=surface['spar_thickness_cp'], units='m')
 
         if 'skin_thickness_cp' in surface.keys():
             n_cp = len(surface['skin_thickness_cp'])
             # Add bspline components for active bspline geometric variables.
-            self.add_subsystem('skin_thickness_bsp', om.BsplinesComp(
-                in_name='skin_thickness_cp', out_name='skin_thickness',
-                num_control_points=n_cp, num_points=int(ny-1), units='m',
-                bspline_order=min(n_cp, 4), distribution='uniform'),
+            x_interp = np.linspace(0., 1., int(ny-1))
+            comp = self.add_subsystem('skin_thickness_bsp', om.SplineComp(
+                method='bsplines', x_interp_val=x_interp,
+                num_cp=n_cp,
+                interp_options={'order' : min(n_cp, 4)}),
                 promotes_inputs=['skin_thickness_cp'], promotes_outputs=['skin_thickness'])
+            comp.add_spline(y_cp_name='skin_thickness_cp', y_interp_name='skin_thickness')
             indep_var_comp.add_output('skin_thickness_cp', val=surface['skin_thickness_cp'], units='m')
 
         self.add_subsystem('wingbox_geometry',

--- a/openaerostruct/tests/test_aero.py
+++ b/openaerostruct/tests/test_aero.py
@@ -7,9 +7,7 @@ class Test(unittest.TestCase):
     def test(self):
         import numpy as np
 
-        from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, \
-            ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, \
-            DirectSolver, LinearBlockGS, PetscKSP, SqliteRecorder
+        import openmdao.api as om
 
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry
@@ -59,11 +57,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the OpenMDAO problem
-        prob = Problem()
+        prob = om.Problem()
 
         # Create an independent variable component that will supply the flow
         # conditions to the problem.
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -101,11 +99,10 @@ class Test(unittest.TestCase):
 
         # Import the Scipy Optimizer and set the driver of the problem to use
         # it, which defaults to an SLSQP optimization method
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        recorder = SqliteRecorder("aero.db")
+        recorder = om.SqliteRecorder("aero.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/tests/test_aero_all_geom.py
+++ b/openaerostruct/tests/test_aero_all_geom.py
@@ -7,9 +7,7 @@ class Test(unittest.TestCase):
     def test(self):
         import numpy as np
 
-        from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, \
-            ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, \
-            DirectSolver, LinearBlockGS, PetscKSP, SqliteRecorder
+        import openmdao.api as om
 
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry
@@ -64,11 +62,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the OpenMDAO problem
-        prob = Problem()
+        prob = om.Problem()
 
         # Create an independent variable component that will supply the flow
         # conditions to the problem.
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -106,8 +104,7 @@ class Test(unittest.TestCase):
 
         # Import the Scipy Optimizer and set the driver of the problem to use
         # it, which defaults to an SLSQP optimization method
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/tests/test_aero_analysis.py
+++ b/openaerostruct/tests/test_aero_analysis.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, SqliteRecorder
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -57,9 +57,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -111,7 +111,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        recorder = SqliteRecorder("aero_analysis.db")
+        recorder = om.SqliteRecorder("aero_analysis.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']
@@ -119,8 +119,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_aero_analysis_Sref.py
+++ b/openaerostruct/tests/test_aero_analysis_Sref.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, SqliteRecorder
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -57,9 +57,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -113,7 +113,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        # recorder = SqliteRecorder("aero_analysis.db")
+        # recorder = om.SqliteRecorder("aero_analysis.db")
         # prob.driver.add_recorder(recorder)
         # prob.driver.recording_options['record_derivatives'] = True
         # prob.driver.recording_options['includes'] = ['*']
@@ -121,8 +121,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_aero_analysis_compressible.py
+++ b/openaerostruct/tests/test_aero_analysis_compressible.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, SqliteRecorder
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -57,9 +57,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_aero_analysis_no_symmetry.py
+++ b/openaerostruct/tests/test_aero_analysis_no_symmetry.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, SqliteRecorder
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -56,9 +56,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -110,7 +110,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        recorder = SqliteRecorder("aero_analysis_no_sym.db")
+        recorder = om.SqliteRecorder("aero_analysis_no_sym.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/tests/test_aero_analysis_no_symmetry_wavedrag.py
+++ b/openaerostruct/tests/test_aero_analysis_no_symmetry_wavedrag.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, SqliteRecorder
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -56,9 +56,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -110,7 +110,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        recorder = SqliteRecorder("aero_analysis_no_sym_wavedrag.db")
+        recorder = om.SqliteRecorder("aero_analysis_no_sym_wavedrag.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/tests/test_aero_atmos.py
+++ b/openaerostruct/tests/test_aero_atmos.py
@@ -7,9 +7,7 @@ class Test(unittest.TestCase):
     def test(self):
         import numpy as np
 
-        from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, \
-            ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, \
-            DirectSolver, LinearBlockGS, PetscKSP, SqliteRecorder
+        import openmdao.api as om
 
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry
@@ -62,11 +60,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the OpenMDAO problem
-        prob = Problem()
+        prob = om.Problem()
 
         # Create an independent variable component that will supply the flow
         # conditions to the problem.
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
         indep_var_comp.add_output('altitude', val=35000., units='ft')
@@ -106,8 +104,7 @@ class Test(unittest.TestCase):
 
         # Import the Scipy Optimizer and set the driver of the problem to use
         # it, which defaults to an SLSQP optimization method
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/tests/test_aero_ffd.py
+++ b/openaerostruct/tests/test_aero_ffd.py
@@ -20,9 +20,8 @@ class Test(unittest.TestCase):
 
         from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-        from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver# TODO, SqliteRecorder, CaseReader, profile
+        import openmdao.api as om
         from openmdao.devtools import iprofile
-        from openmdao.api import view_model
         from six import iteritems
         from pygeo import DVGeometry
 
@@ -72,9 +71,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=6.64, units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -128,8 +127,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        from openmdao.api import pyOptSparseDriver
-        prob.driver = pyOptSparseDriver()
+        prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SNOPT"
         prob.driver.opt_settings = {'Major optimality tolerance': 1.0e-6,
                                     'Major feasibility tolerance': 1.0e-6}
@@ -145,7 +143,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # view_model(prob, outfile='aero.html', show_browser=False)
+        # om.view_model(prob, outfile='aero.html', show_browser=False)
 
         # prob.run_model()
         prob.run_driver()

--- a/openaerostruct/tests/test_aero_morphing_multipoint.py
+++ b/openaerostruct/tests/test_aero_morphing_multipoint.py
@@ -12,7 +12,7 @@ from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 from openaerostruct.integration.multipoint_comps import MultiCD
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, ExplicitComponent, ExecComp# TODO, SqliteRecorder, CaseReader, profile
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -67,9 +67,9 @@ class Test(unittest.TestCase):
         n_points = 2
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=6.64, units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -81,7 +81,7 @@ class Test(unittest.TestCase):
             indep_var_comp,
             promotes=['*'])
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('t_over_c_cp', val=np.array([0.15]))
         indep_var_comp.add_output('span', val=12., units='m')
         indep_var_comp.add_output('twist_cp_0', val=np.zeros((5)), units='deg')
@@ -144,8 +144,7 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem('multi_CD', MultiCD(n_points=n_points), promotes_outputs=['CD'])
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
 

--- a/openaerostruct/tests/test_aero_opt_no_symmetry.py
+++ b/openaerostruct/tests/test_aero_opt_no_symmetry.py
@@ -7,9 +7,7 @@ class Test(unittest.TestCase):
     def test(self):
         import numpy as np
 
-        from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, \
-            ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, \
-            DirectSolver, LinearBlockGS, PetscKSP, SqliteRecorder
+        import openmdao.api as om
 
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry
@@ -59,11 +57,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the OpenMDAO problem
-        prob = Problem()
+        prob = om.Problem()
 
         # Create an independent variable component that will supply the flow
         # conditions to the problem.
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -101,8 +99,7 @@ class Test(unittest.TestCase):
 
         # Import the Scipy Optimizer and set the driver of the problem to use
         # it, which defaults to an SLSQP optimization method
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/tests/test_aero_opt_wavedrag.py
+++ b/openaerostruct/tests/test_aero_opt_wavedrag.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, SqliteRecorder
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -56,9 +56,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -110,11 +110,10 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        recorder = SqliteRecorder("aero_opt_wavedrag.db")
+        recorder = om.SqliteRecorder("aero_opt_wavedrag.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/tests/test_aerostruct.py
+++ b/openaerostruct/tests/test_aerostruct.py
@@ -13,7 +13,7 @@ class Test(unittest.TestCase):
         from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
         from openaerostruct.utils.constants import grav_constant
 
-        from openmdao.api import IndepVarComp, Problem, Group, SqliteRecorder
+        import openmdao.api as om
 
         # Create a dictionary to store options about the surface
         mesh_dict = {'num_y' : 5,
@@ -70,10 +70,10 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -121,11 +121,10 @@ class Test(unittest.TestCase):
         prob.model.connect(name + '.structural_mass', point_name + '.' + 'total_perf.' + name + '_structural_mass')
         prob.model.connect(name + '.t_over_c', com_name + '.t_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        recorder = SqliteRecorder("aerostruct.db")
+        recorder = om.SqliteRecorder("aerostruct.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/tests/test_aerostruct_analysis.py
+++ b/openaerostruct/tests/test_aerostruct_analysis.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -71,10 +71,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_aerostruct_analysis_Sref.py
+++ b/openaerostruct/tests/test_aerostruct_analysis_Sref.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -71,10 +71,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -149,8 +149,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_aerostruct_analysis_compressible.py
+++ b/openaerostruct/tests/test_aerostruct_analysis_compressible.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -71,10 +71,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_aerostruct_engine_thrusts.py
+++ b/openaerostruct/tests/test_aerostruct_engine_thrusts.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -72,10 +72,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_aerostruct_ffd.py
+++ b/openaerostruct/tests/test_aerostruct_ffd.py
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
 
         from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-        from openmdao.api import IndepVarComp, Problem, Group, SqliteRecorder
+        import openmdao.api as om
         from pygeo import DVGeometry
 
 
@@ -82,10 +82,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -159,10 +159,9 @@ class Test(unittest.TestCase):
 
         # Import the Scipy Optimizer and set the driver of the problem to use
         # it, which defaults to an SLSQP optimization method
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
-        recorder = SqliteRecorder("aerostruct_ffd.db")
+        recorder = om.SqliteRecorder("aerostruct_ffd.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']
@@ -184,8 +183,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob, outfile='aerostruct_ffd', show_browser=False)
+        # om.view_model(prob, outfile='aerostruct_ffd', show_browser=False)
 
         # prob.run_model()
         prob.run_driver()

--- a/openaerostruct/tests/test_aerostruct_point_loads.py
+++ b/openaerostruct/tests/test_aerostruct_point_loads.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -72,10 +72,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_aerostruct_wingbox_+weight_analysis.py
+++ b/openaerostruct/tests/test_aerostruct_wingbox_+weight_analysis.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 # Provide coordinates for a portion of an airfoil for the wingbox cross-section as an nparray with dtype=complex (to work with the complex-step approximation for derivatives).
@@ -92,10 +92,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -175,8 +175,7 @@ class Test(unittest.TestCase):
                 prob.model.connect(name + '.spar_thickness', com_name + 'spar_thickness')
                 prob.model.connect(name + '.t_over_c', com_name + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = True
 
@@ -185,8 +184,7 @@ class Test(unittest.TestCase):
 
         AS_point.nonlinear_solver.options['iprint'] = 2
         #
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_aerostruct_wingbox_analysis.py
+++ b/openaerostruct/tests/test_aerostruct_wingbox_analysis.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 # Provide coordinates for a portion of an airfoil for the wingbox cross-section as an nparray with dtype=complex (to work with the complex-step approximation for derivatives).
@@ -92,10 +92,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -175,15 +175,13 @@ class Test(unittest.TestCase):
                 prob.model.connect(name + '.spar_thickness', com_name + 'spar_thickness')
                 prob.model.connect(name + '.t_over_c', com_name + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # Set up the problem
         prob.setup()
         #
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_aerostruct_wingbox_fuel_vol_constraint_opt.py
+++ b/openaerostruct/tests/test_aerostruct_wingbox_fuel_vol_constraint_opt.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.structures.wingbox_fuel_vol_delta import WingboxFuelVolDelta
 
 # Provide coordinates for a portion of an airfoil for the wingbox cross-section as an nparray with dtype=complex (to work with the complex-step approximation for derivatives).
@@ -97,10 +97,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -189,13 +189,11 @@ class Test(unittest.TestCase):
             #=======================================================================================
             #=======================================================================================
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        # from openmdao.api import pyOptSparseDriver
-        # prob.driver = pyOptSparseDriver()
-        # # prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        # prob.driver = om.pyOptSparseDriver()
+        # # prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
         # prob.driver.options['optimizer'] = "SNOPT"
         # prob.driver.opt_settings['Major optimality tolerance'] = 1e-6
         # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
@@ -221,8 +219,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_aerostruct_wingbox_opt.py
+++ b/openaerostruct/tests/test_aerostruct_wingbox_opt.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 # Provide coordinates for a portion of an airfoil for the wingbox cross-section as an nparray with dtype=complex (to work with the complex-step approximation for derivatives).
@@ -93,10 +93,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -176,18 +176,16 @@ class Test(unittest.TestCase):
                 prob.model.connect(name + '.spar_thickness', com_name + 'spar_thickness')
                 prob.model.connect(name + '.t_over_c', com_name + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver, SqliteRecorder
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        # from openmdao.api import pyOptSparseDriver
-        # prob.driver = pyOptSparseDriver()
+        # prob.driver = om.pyOptSparseDriver()
         # prob.driver.options['optimizer'] = "SNOPT"
         # prob.driver.opt_settings['Major optimality tolerance'] = 1e-6
         # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
         # prob.driver.opt_settings['Major iterations limit'] = 200
 
-        # prob.driver.add_recorder(SqliteRecorder("wingbox.db"))
+        # prob.driver.add_recorder(om.SqliteRecorder("wingbox.db"))
         # prob.driver.recording_options['record_derivatives'] = True
         # prob.driver.recording_options['includes'] = ['*']
 
@@ -208,8 +206,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_aerostruct_wingbox_wave_fuel_vol_constraint_opt.py
+++ b/openaerostruct/tests/test_aerostruct_wingbox_wave_fuel_vol_constraint_opt.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, SqliteRecorder
+import openmdao.api as om
 from openaerostruct.structures.wingbox_fuel_vol_delta import WingboxFuelVolDelta
 
 
@@ -98,10 +98,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -190,13 +190,11 @@ class Test(unittest.TestCase):
             #=======================================================================================
             #=======================================================================================
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        # from openmdao.api import pyOptSparseDriver
-        # prob.driver = pyOptSparseDriver()
-        # prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        # prob.driver = om.pyOptSparseDriver()
+        # prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
         # prob.driver.options['optimizer'] = "SNOPT"
         # prob.driver.opt_settings['Major optimality tolerance'] = 1e-6
         # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
@@ -222,8 +220,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_morphing_aerostruct.py
+++ b/openaerostruct/tests/test_morphing_aerostruct.py
@@ -20,7 +20,7 @@ class Test(unittest.TestCase):
         from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
         from openaerostruct.utils.constants import grav_constant
 
-        from openmdao.api import IndepVarComp, Problem, Group, SqliteRecorder
+        import openmdao.api as om
 
         # Create a dictionary to store options about the surface
         mesh_dict = {'num_y' : 11,
@@ -77,10 +77,10 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=[248.136, 0.5 * 340.], units='m/s')
         indep_var_comp.add_output('alpha', val=[5., 10.], units='deg')
         indep_var_comp.add_output('Mach_number', val=[0.84, 0.5])
@@ -98,7 +98,7 @@ class Test(unittest.TestCase):
              promotes=['*'])
 
         # Add morphing variables as an independent variables component
-        morphing_vars = IndepVarComp()
+        morphing_vars = om.IndepVarComp()
         morphing_vars.add_output('t_over_c_cp', val=np.array([0.15]))
         morphing_vars.add_output('thickness_cp', val=np.array([0.01, 0.01, 0.01]), units='m')
         morphing_vars.add_output('twist_cp_0', val=np.array([2., 3., 4., 4., 4.]), units='deg')
@@ -161,12 +161,11 @@ class Test(unittest.TestCase):
             AS_point.connect(name + '.geometry.t_over_c', name + '_perf' + '.t_over_c')
             AS_point.connect(name + '.geometry.t_over_c', name + '.t_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['maxiter'] = 2
 
-        recorder = SqliteRecorder("morphing_aerostruct.db")
+        recorder = om.SqliteRecorder("morphing_aerostruct.db")
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']
@@ -189,8 +188,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup(check=True)
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_multi_aero_ffd.py
+++ b/openaerostruct/tests/test_multi_aero_ffd.py
@@ -21,9 +21,8 @@ class Test(unittest.TestCase):
         from openaerostruct.aerodynamics.aero_groups import AeroPoint
         from openaerostruct.integration.multipoint_comps import MultiCD
 
-        from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, ExplicitComponent# TODO, SqliteRecorder, CaseReader, profile
+        import openmdao.api as om
         from openmdao.devtools import iprofile
-        from openmdao.api import view_model
         from openmdao.utils.assert_utils import assert_check_partials
         from pygeo import DVGeometry
 
@@ -75,9 +74,9 @@ class Test(unittest.TestCase):
         n_points = 2
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=np.ones(n_points)*6.64, units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -132,8 +131,7 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem('multi_CD', MultiCD(n_points=n_points), promotes_outputs=['CD'])
 
-        from openmdao.api import pyOptSparseDriver
-        prob.driver = pyOptSparseDriver()
+        prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SNOPT"
         prob.driver.opt_settings = {'Major optimality tolerance': 1.0e-5,
                                     'Major feasibility tolerance': 1.0e-5}

--- a/openaerostruct/tests/test_multiple_aero_analysis.py
+++ b/openaerostruct/tests/test_multiple_aero_analysis.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -19,8 +19,6 @@ class Test(unittest.TestCase):
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry
         from openaerostruct.aerodynamics.aero_groups import AeroPoint
-
-        from openmdao.api import IndepVarComp, Problem
 
 
         # Create a dictionary to store options about the surface
@@ -107,9 +105,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict, surf_dict2]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_multiple_aero_analysis.py
+++ b/openaerostruct/tests/test_multiple_aero_analysis.py
@@ -7,14 +7,14 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-import openmdao.api as om
-
 
 class Test(unittest.TestCase):
 
     def test(self):
 
         import numpy as np
+        
+        import openmdao.api as om
 
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry

--- a/openaerostruct/tests/test_multiple_rect.py
+++ b/openaerostruct/tests/test_multiple_rect.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -95,9 +95,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict, surf_dict2]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_multipoint_aero.py
+++ b/openaerostruct/tests/test_multipoint_aero.py
@@ -15,7 +15,7 @@ class Test(unittest.TestCase):
         from openaerostruct.aerodynamics.aero_groups import AeroPoint
         from openaerostruct.integration.multipoint_comps import MultiCD
 
-        from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, ExplicitComponent# TODO, SqliteRecorder, CaseReader, profile
+        import openmdao.api as om
 
         # Create a dictionary to store options about the surface
         mesh_dict = {'num_y' : 5,
@@ -64,9 +64,9 @@ class Test(unittest.TestCase):
         n_points = 2
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=np.ones(n_points)*6.64, units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -118,8 +118,7 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem('multi_CD', MultiCD(n_points=n_points), promotes_outputs=['CD'])
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/tests/test_multipoint_wingbox_aerostruct.py
+++ b/openaerostruct/tests/test_multipoint_wingbox_aerostruct.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, ScipyOptimizeDriver, SqliteRecorder, ExecComp
+import openmdao.api as om
 from openaerostruct.structures.wingbox_fuel_vol_delta import WingboxFuelVolDelta
 
 
@@ -98,10 +98,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('alpha_maneuver', val=0., units='deg')
@@ -202,13 +202,13 @@ class Test(unittest.TestCase):
         prob.model.connect('wing.struct_setup.fuel_vols', 'AS_point_1.coupled.wing.struct_states.fuel_vols')
         prob.model.connect('fuel_mass', 'AS_point_1.coupled.wing.struct_states.fuel_mass')
 
-        comp = ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
+        comp = om.ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
         prob.model.add_subsystem('fuel_diff', comp,
             promotes_inputs=['fuel_mass'],
             promotes_outputs=['fuel_diff'])
         prob.model.connect('AS_point_0.fuelburn', 'fuel_diff.fuelburn')
 
-        comp = ExecComp('fuel_diff_25 = (fuel_mass - fuelburn) / fuelburn')
+        comp = om.ExecComp('fuel_diff_25 = (fuel_mass - fuelburn) / fuelburn')
         prob.model.add_subsystem('fuel_diff_25', comp,
             promotes_inputs=['fuel_mass'],
             promotes_outputs=['fuel_diff_25'])
@@ -216,13 +216,11 @@ class Test(unittest.TestCase):
         #=======================================================================================
         #=======================================================================================
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        # from openmdao.api import pyOptSparseDriver
-        # prob.driver = pyOptSparseDriver()
-        # prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        # prob.driver = om.pyOptSparseDriver()
+        # prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
         # prob.driver.options['optimizer'] = "SNOPT"
         # prob.driver.opt_settings['Major optimality tolerance'] = 5e-6
         # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
@@ -254,8 +252,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_multipoint_wingbox_derivs.py
+++ b/openaerostruct/tests/test_multipoint_wingbox_derivs.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, ScipyOptimizeDriver, SqliteRecorder, ExecComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 from openaerostruct.structures.wingbox_fuel_vol_delta import WingboxFuelVolDelta
 
@@ -98,10 +98,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -199,13 +199,13 @@ class Test(unittest.TestCase):
         prob.model.connect('wing.struct_setup.fuel_vols', 'AS_point_1.coupled.wing.struct_states.fuel_vols')
         prob.model.connect('fuel_mass', 'AS_point_1.coupled.wing.struct_states.fuel_mass')
 
-        comp = ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
+        comp = om.ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
         prob.model.add_subsystem('fuel_diff', comp,
             promotes_inputs=['fuel_mass'],
             promotes_outputs=['fuel_diff'])
         prob.model.connect('AS_point_0.fuelburn', 'fuel_diff.fuelburn')
 
-        comp = ExecComp('fuel_diff_25 = (fuel_mass - fuelburn) / fuelburn')
+        comp = om.ExecComp('fuel_diff_25 = (fuel_mass - fuelburn) / fuelburn')
         prob.model.add_subsystem('fuel_diff_25', comp,
             promotes_inputs=['fuel_mass'],
             promotes_outputs=['fuel_diff_25'])
@@ -213,14 +213,12 @@ class Test(unittest.TestCase):
         #=======================================================================================
         #=======================================================================================
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['maxiter'] = 5
 
-        # from openmdao.api import pyOptSparseDriver
-        # prob.driver = pyOptSparseDriver()
-        # prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        # prob.driver = om.pyOptSparseDriver()
+        # prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
         # prob.driver.options['optimizer'] = "SNOPT"
         # prob.driver.opt_settings['Major optimality tolerance'] = 1e-6
         # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
@@ -249,8 +247,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_simple_rect_AS.py
+++ b/openaerostruct/tests/test_simple_rect_AS.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver, LinearRunOnce
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -71,10 +71,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=9., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -144,8 +144,7 @@ class Test(unittest.TestCase):
                 prob.model.connect(name + '.structural_mass', point_name + '.' + 'total_perf.' + name + '_structural_mass')
                 prob.model.connect(name + '.t_over_c', com_name + '.t_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/tests/test_simple_rect_aero.py
+++ b/openaerostruct/tests/test_simple_rect_aero.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from openaerostruct.geometry.utils import generate_mesh
@@ -58,9 +58,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_simple_rect_aero_roll.py
+++ b/openaerostruct/tests/test_simple_rect_aero_roll.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from openaerostruct.geometry.utils import generate_mesh
@@ -58,9 +58,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('omega', val=np.array([30.0, 0.0, 0.0]), units='deg/s')

--- a/openaerostruct/tests/test_simple_rect_aero_sideslip.py
+++ b/openaerostruct/tests/test_simple_rect_aero_sideslip.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from openaerostruct.geometry.utils import generate_mesh
@@ -58,9 +58,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('beta', val=-5, units='deg')

--- a/openaerostruct/tests/test_simple_rect_aero_wo_symmetry.py
+++ b/openaerostruct/tests/test_simple_rect_aero_wo_symmetry.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Problem
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from openaerostruct.geometry.utils import generate_mesh
@@ -58,9 +58,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)

--- a/openaerostruct/tests/test_struct.py
+++ b/openaerostruct/tests/test_struct.py
@@ -14,7 +14,7 @@ class Test(unittest.TestCase):
         from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
         from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-        from openmdao.api import IndepVarComp, Problem, Group, SqliteRecorder
+        import openmdao.api as om
 
         # Create a dictionary to store options about the surface
         mesh_dict = {'num_y' : 7,
@@ -48,11 +48,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surf_dict['mesh'].shape[1]
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.ones((ny, 6)) * 2e5, units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 
@@ -65,12 +65,11 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem(surf_dict['name'], struct_group)
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['disp'] = True
         prob.driver.options['tol'] = 1e-9
 
-        recorder = SqliteRecorder('struct.db')
+        recorder = om.SqliteRecorder('struct.db')
         prob.driver.add_recorder(recorder)
         prob.driver.recording_options['record_derivatives'] = True
         prob.driver.recording_options['includes'] = ['*']

--- a/openaerostruct/tests/test_struct_analysis.py
+++ b/openaerostruct/tests/test_struct_analysis.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -48,11 +48,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surf_dict['mesh'].shape[1]
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.ones((ny, 6)) * 2e5, units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 

--- a/openaerostruct/tests/test_struct_analysis_2g.py
+++ b/openaerostruct/tests/test_struct_analysis_2g.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -47,11 +47,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surf_dict['mesh'].shape[1]
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.ones((ny, 6)) * 2e5, units='N')
         indep_var_comp.add_output('load_factor', val=2.)
 

--- a/openaerostruct/tests/test_struct_engine_thrusts.py
+++ b/openaerostruct/tests/test_struct_engine_thrusts.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -47,12 +47,12 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surface['mesh'].shape[1]
         surface['n_point_masses'] = 1
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.zeros((ny, 6)), units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 
@@ -113,12 +113,12 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surface['mesh'].shape[1]
         surface['n_point_masses'] = 2
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.zeros((ny, 6)), units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 

--- a/openaerostruct/tests/test_struct_no_loads.py
+++ b/openaerostruct/tests/test_struct_no_loads.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -47,11 +47,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surf_dict['mesh'].shape[1]
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.zeros((ny, 6)), units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 
@@ -64,8 +64,7 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem(surf_dict['name'], struct_group, promotes=['*'])
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         # Setup problem and add design variables, constraint, and objective
         prob.model.add_design_var('thickness_cp', lower=0.01, upper=0.5, scaler=1e2)
@@ -77,8 +76,6 @@ class Test(unittest.TestCase):
 
         # Set up the problem
         prob.setup()
-
-        from openmdao.api import view_model
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_struct_point_masses.py
+++ b/openaerostruct/tests/test_struct_point_masses.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -47,12 +47,12 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surface['mesh'].shape[1]
         surface['n_point_masses'] = 1
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.zeros((ny, 6)), units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 
@@ -113,12 +113,12 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surface['mesh'].shape[1]
         surface['n_point_masses'] = 2
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.zeros((ny, 6)), units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 

--- a/openaerostruct/tests/test_v1_aero_analysis.py
+++ b/openaerostruct/tests/test_v1_aero_analysis.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -59,9 +59,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -113,8 +113,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         # # Setup problem and add design variables, constraint, and objective
         prob.model.add_design_var('wing.twist_cp', lower=-10., upper=15.)

--- a/openaerostruct/tests/test_v1_aero_opt.py
+++ b/openaerostruct/tests/test_v1_aero_opt.py
@@ -12,12 +12,12 @@ class Test(unittest.TestCase):
         from openaerostruct.geometry.geometry_group import Geometry
         from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-        from openmdao.api import IndepVarComp, Problem, Group
+        import openmdao.api as om
 
         # Instantiate the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -104,8 +104,7 @@ class Test(unittest.TestCase):
 
         prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         # # Setup problem and add design variables, constraint, and objective
         prob.model.add_design_var('wing.twist_cp', lower=-10., upper=15.)

--- a/openaerostruct/tests/test_v1_aero_viscous.py
+++ b/openaerostruct/tests/test_v1_aero_viscous.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -59,9 +59,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -113,8 +113,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         # # Setup problem and add design variables, constraint, and objective
         prob.model.add_design_var('wing.twist_cp', lower=-10., upper=15.)

--- a/openaerostruct/tests/test_v1_aero_viscous_opt.py
+++ b/openaerostruct/tests/test_v1_aero_viscous_opt.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.aerodynamics.aero_groups import AeroPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -61,9 +61,9 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and the model group
-        prob = Problem()
+        prob = om.Problem()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -115,8 +115,7 @@ class Test(unittest.TestCase):
 
                 prob.model.connect(name + '.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-5
 
         # # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/tests/test_v1_aerostruct_analysis.py
+++ b/openaerostruct/tests/test_v1_aerostruct_analysis.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -72,10 +72,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -149,8 +149,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_v1_aerostruct_opt.py
+++ b/openaerostruct/tests/test_v1_aerostruct_opt.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 from openaerostruct.utils.constants import grav_constant
 
 
@@ -72,10 +72,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
@@ -145,8 +145,7 @@ class Test(unittest.TestCase):
                 prob.model.connect(name + '.structural_mass', point_name + '.' + 'total_perf.' + name + '_structural_mass')
                 prob.model.connect(name + '.t_over_c', com_name + '.t_over_c')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # Setup problem and add design variables, constraint, and objective
@@ -163,8 +162,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_v1_struct_analysis.py
+++ b/openaerostruct/tests/test_v1_struct_analysis.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -50,13 +50,13 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surf_dict['mesh'].shape[1]
 
         loads = np.zeros((ny, 6))
         loads[0, 2] = 1e4
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=loads, units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 
@@ -69,8 +69,7 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem(surf_dict['name'], struct_group)
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['disp'] = True
 
         # Setup problem and add design variables, constraint, and objective
@@ -84,8 +83,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_v1_struct_opt.py
+++ b/openaerostruct/tests/test_v1_struct_opt.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.geometry_group import Geometry
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 
-from openmdao.api import IndepVarComp, Problem, Group, NewtonSolver, ScipyIterativeSolver, LinearBlockGS, NonlinearBlockGS, DirectSolver, LinearBlockGS, PetscKSP, ScipyOptimizeDriver
+import openmdao.api as om
 
 
 class Test(unittest.TestCase):
@@ -50,13 +50,13 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surf_dict['mesh'].shape[1]
 
         loads = np.zeros((ny, 6))
         loads[0, 2] = 1e4
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=loads, units='N')
         indep_var_comp.add_output('load_factor', val=1.)
 
@@ -69,8 +69,7 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem(surf_dict['name'], struct_group)
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['disp'] = True
         prob.driver.options['tol'] = 1e-9
 
@@ -85,8 +84,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/tests/test_wingbox_analysis.py
+++ b/openaerostruct/tests/test_wingbox_analysis.py
@@ -6,7 +6,7 @@ from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.structures.struct_groups import SpatialBeamAlone
 from openmdao.utils.assert_utils import assert_check_partials
 from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.api import IndepVarComp, Problem, Group, SqliteRecorder
+import openmdao.api as om
 
 upper_x = np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6], dtype = 'complex128')
 lower_x = np.array([0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6], dtype = 'complex128')
@@ -79,11 +79,11 @@ class Test(unittest.TestCase):
                     }
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         ny = surf_dict['mesh'].shape[1]
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('loads', val=np.ones((ny, 6)) * 2e5, units='N')
         indep_var_comp.add_output('load_factor', val=1.)
         indep_var_comp.add_output('fuel_mass', val=10000., units='kg')
@@ -97,8 +97,7 @@ class Test(unittest.TestCase):
             prob.model.connect('wing.fuel_mass', 'wing.struct_states.fuel_mass')
             prob.model.connect('wing.struct_setup.fuel_vols', 'wing.struct_states.fuel_vols')
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
         # Setup problem and add design variables, constraint, and objective

--- a/openaerostruct/tests/test_wingbox_derivs.py
+++ b/openaerostruct/tests/test_wingbox_derivs.py
@@ -8,7 +8,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, ScipyOptimizeDriver, SqliteRecorder, ExecComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 from openaerostruct.structures.wingbox_fuel_vol_delta import WingboxFuelVolDelta
 
@@ -102,10 +102,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -197,7 +197,7 @@ class Test(unittest.TestCase):
             prob.model.connect('wing.struct_setup.fuel_vols', 'AS_point_0.coupled.wing.struct_states.fuel_vols')
             prob.model.connect('fuel_mass', 'AS_point_0.coupled.wing.struct_states.fuel_mass')
 
-            comp = ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn',
+            comp = om.ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn',
                             fuel_mass={'value' : 1.0, 'units' : 'kg'},
                             fuelburn= {'value' : 1.0, 'units' : 'kg'})
             prob.model.add_subsystem('fuel_diff', comp,
@@ -207,14 +207,12 @@ class Test(unittest.TestCase):
             #=======================================================================================
             #=======================================================================================
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['maxiter'] = 2
 
-        # from openmdao.api import pyOptSparseDriver
-        # prob.driver = pyOptSparseDriver()
-        # prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        # prob.driver = om.pyOptSparseDriver()
+        # prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
         # prob.driver.options['optimizer'] = "SNOPT"
         # prob.driver.opt_settings['Major optimality tolerance'] = 1e-6
         # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
@@ -242,8 +240,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_model()
 

--- a/openaerostruct/tests/test_wingbox_distributed_fuel.py
+++ b/openaerostruct/tests/test_wingbox_distributed_fuel.py
@@ -7,7 +7,7 @@ from openaerostruct.geometry.utils import generate_mesh
 
 from openaerostruct.integration.aerostruct_groups import AerostructGeometry, AerostructPoint
 
-from openmdao.api import IndepVarComp, Problem, Group, ScipyOptimizeDriver, SqliteRecorder, ExecComp
+import openmdao.api as om
 from openaerostruct.structures.wingbox_fuel_vol_delta import WingboxFuelVolDelta
 
 
@@ -98,10 +98,10 @@ class Test(unittest.TestCase):
         surfaces = [surf_dict]
 
         # Create the problem and assign the model group
-        prob = Problem()
+        prob = om.Problem()
 
         # Add problem information as an independent variables component
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=.85 * 295.07, units='m/s')
         indep_var_comp.add_output('alpha', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.85)
@@ -193,7 +193,7 @@ class Test(unittest.TestCase):
             prob.model.connect('wing.struct_setup.fuel_vols', 'AS_point_0.coupled.wing.struct_states.fuel_vols')
             prob.model.connect('fuel_mass', 'AS_point_0.coupled.wing.struct_states.fuel_mass')
 
-            comp = ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
+            comp = om.ExecComp('fuel_diff = (fuel_mass - fuelburn) / fuelburn', units='kg')
             prob.model.add_subsystem('fuel_diff', comp,
                 promotes_inputs=['fuel_mass'],
                 promotes_outputs=['fuel_diff'])
@@ -201,13 +201,11 @@ class Test(unittest.TestCase):
             #=======================================================================================
             #=======================================================================================
 
-        from openmdao.api import ScipyOptimizeDriver
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1e-9
 
-        # from openmdao.api import pyOptSparseDriver
-        # prob.driver = pyOptSparseDriver()
-        # prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        # prob.driver = om.pyOptSparseDriver()
+        # prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
         # prob.driver.options['optimizer'] = "SNOPT"
         # prob.driver.opt_settings['Major optimality tolerance'] = 1e-6
         # prob.driver.opt_settings['Major feasibility tolerance'] = 1e-8
@@ -235,8 +233,7 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup()
 
-        # from openmdao.api import view_model
-        # view_model(prob)
+        # om.view_model(prob)
 
         prob.run_driver()
 

--- a/openaerostruct/transfer/compute_transformation_matrix.py
+++ b/openaerostruct/transfer/compute_transformation_matrix.py
@@ -1,12 +1,12 @@
 from __future__ import print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.utils.vector_algebra import get_array_indices
 
 
-class ComputeTransformationMatrix(ExplicitComponent):
+class ComputeTransformationMatrix(om.ExplicitComponent):
     """
     Compute the transformation matrix used to apply the rotations obtained
     from the FEM system to the aerodynamic mesh.

--- a/openaerostruct/transfer/displacement_transfer.py
+++ b/openaerostruct/transfer/displacement_transfer.py
@@ -1,14 +1,14 @@
 from __future__ import division, print_function
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from openaerostruct.utils.vector_algebra import get_array_indices
 
 
 np.random.seed(314)
 
-class DisplacementTransfer(ExplicitComponent):
+class DisplacementTransfer(om.ExplicitComponent):
     """
     Apply the computed FEM displacements and rotations on the aerodynamic mesh
     to obtain the deformed mesh.

--- a/openaerostruct/transfer/displacement_transfer_group.py
+++ b/openaerostruct/transfer/displacement_transfer_group.py
@@ -1,9 +1,9 @@
-from openmdao.api import Group
+import openmdao.api as om
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.transfer.compute_transformation_matrix import ComputeTransformationMatrix
 
 
-class DisplacementTransferGroup(Group):
+class DisplacementTransferGroup(om.Group):
     """
     These components take the displacements and rotations obtained by
     solving the FEM problem and applies them to the aerodynamic mesh

--- a/openaerostruct/transfer/load_transfer.py
+++ b/openaerostruct/transfer/load_transfer.py
@@ -2,10 +2,10 @@ from __future__ import division, print_function
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class LoadTransfer(ExplicitComponent):
+class LoadTransfer(om.ExplicitComponent):
     """
     Perform aerodynamic load transfer.
 

--- a/openaerostruct/transfer/tests/test_compute_transformation_matrix.py
+++ b/openaerostruct/transfer/tests/test_compute_transformation_matrix.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from openmdao.api import IndepVarComp, Group
+import openmdao.api as om
 
 from openaerostruct.transfer.compute_transformation_matrix import ComputeTransformationMatrix
 from openaerostruct.utils.testing import run_test, get_default_surfaces
@@ -15,9 +15,9 @@ class Test(unittest.TestCase):
 
         comp = ComputeTransformationMatrix(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
         disp = np.random.random_sample((ny, 6)) * 100.

--- a/openaerostruct/transfer/tests/test_displacement_transfer.py
+++ b/openaerostruct/transfer/tests/test_displacement_transfer.py
@@ -1,5 +1,5 @@
 import unittest
-from openmdao.api import IndepVarComp, Group
+import openmdao.api as om
 
 from openaerostruct.transfer.displacement_transfer import DisplacementTransfer
 from openaerostruct.utils.testing import run_test, get_default_surfaces
@@ -12,9 +12,9 @@ class Test(unittest.TestCase):
 
         comp = DisplacementTransfer(surface=surface)
 
-        group = Group()
+        group = om.Group()
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         ny = surface['mesh'].shape[1]
 

--- a/openaerostruct/transfer/tests/test_load_transfer.py
+++ b/openaerostruct/transfer/tests/test_load_transfer.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from openaerostruct.transfer.load_transfer import LoadTransfer
 from openaerostruct.utils.testing import run_test, get_default_surfaces
 
@@ -10,11 +10,11 @@ class Test(unittest.TestCase):
 
     def test(self):
         surface = get_default_surfaces()[0]
-        group = Group()
+        group = om.Group()
 
         comp = LoadTransfer(surface=surface)
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
 
         nx = surface['mesh'].shape[0]
         ny = surface['mesh'].shape[1]

--- a/openaerostruct/utils/testing.py
+++ b/openaerostruct/utils/testing.py
@@ -1,4 +1,4 @@
-from openmdao.api import Problem, Group, IndepVarComp, view_model
+import openmdao.api as om
 
 from six import iteritems
 from numpy.testing import assert_almost_equal
@@ -72,7 +72,7 @@ def view_mat(mat1, mat2=None, key='Title', tol=1e-10):  # pragma: no cover
     plt.show()
 
 def run_test(test_obj, comp, complex_flag=False, compact_print=True, method='fd', step=1e-6, atol=1e-5, rtol=1e-5, view=False):
-    prob = Problem()
+    prob = om.Problem()
     prob.model.add_subsystem('comp', comp)
     prob.setup(force_alloc_complex=complex_flag)
 


### PR DESCRIPTION
## Purpose
OpenMDAO recently released version 3.0 and OpenAeroStruct was not fully compatible with its new API.
This PR updates all OAS code to be OM 3.0 compliant.
The previous PR didn't trigger a Travis build, so I'm creating this new PR.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)

## Testing
Tests pass locally with OM master

## Checklist
_Put an `x` in the boxes that apply._

- [X] I have run unit and regression tests which pass locally with my changes
