### PR TITLE
Updated readme and installation guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,8 @@ install:
 - export PATH=$HOME/.local/bin:$PATH;
 
 # install openmdao and sphinx-travis
-- git clone https://github.com/openmdao/openmdao.git;
-- cd openmdao;
+- pip install `openmdao==3.1.0`
 - pip install --user travis-sphinx;
-- pip install ".[docs]";
-- cd ..;
 
 # install openaerostruct itself
 - pip install -e .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 - export PATH=$HOME/.local/bin:$PATH;
 
 # install openmdao and sphinx-travis
-- pip install `openmdao==3.1.0`
+- pip install openmdao
 - pip install --user travis-sphinx;
 
 # install openaerostruct itself

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 - export PATH=/home/travis/miniconda/bin:$PATH;
 
 install:
-- conda install --yes python=$PY numpy scipy nose sphinx mock swig pip;
+- conda install --yes python=$PY numpy scipy nose sphinx mock swig pip matplotlib numpydoc redbaron;
 - pip install --upgrade pip;
 - pip install mpi4py;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 - export PATH=/home/travis/miniconda/bin:$PATH;
 
 install:
-- conda install --yes python=$PY numpy scipy nose sphinx mock swig pip matplotlib numpydoc redbaron;
+- conda install --yes python=$PY numpy scipy nose sphinx mock swig pip matplotlib numpydoc;
 - pip install --upgrade pip;
 - pip install mpi4py;
 
@@ -42,6 +42,7 @@ install:
 # install openmdao and sphinx-travis
 - pip install openmdao
 - pip install --user travis-sphinx;
+- pip install redbaron
 
 # install openaerostruct itself
 - pip install -e .;

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Shamsheer S. Chauhan and Joaquim R. R. A. Martins, “Low-Fidelity Aerostructura
 
 Version Information
 -------------------
-This version of OpenAeroStruct requires the LATEST master version of [OpenMDAO](https://github.com/OpenMDAO/openmdao) available on GitHub and Python3.
+This version of OpenAeroStruct requires [OpenMDAO](https://github.com/OpenMDAO/openmdao) 3.1+ and Python3.
 Python2 is no longer supported.
-If you are looking to use the previous version of OpenAeroStruct which uses OpenMDAO 1.7.4, use OpenAeroStruct v1.0 from [here](https://github.com/mdolab/OpenAeroStruct/releases).
+If you are looking to use the previous version of OpenAeroStruct which uses OpenMDAO 1.7.4, use OpenAeroStruct 1.0 from [here](https://github.com/mdolab/OpenAeroStruct/releases).
 
 License
 -------
-Copyright 2018 MDO Lab
+Copyright 2018-2020 MDO Lab
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/openaerostruct/docs/installation.rst
+++ b/openaerostruct/docs/installation.rst
@@ -3,15 +3,8 @@
 Installation
 ============
 
-This version of OpenAeroStruct is only compatible with Python3.
-To use OpenAeroStruct, you must first install the LATEST master version of OpenMDAO by cloning or downloading it from https://github.com/OpenMDAO/OpenMDAO/.
-Then, navigate into the OpenMDAO folder and install it using pip:
-
-.. code-block:: bash
-
-    pip install .
-
-or by following the instructions at https://github.com/openmdao/openmdao. If you are unfamiliar with OpenMDAO and wish to modify the internals of OpenAeroStruct, you should examine the OpenMDAO documentation at http://openmdao.org/twodocs/versions/latest/index.html. The tutorials provided with OpenMDAO are helpful to understand the basics of using OpenMDAO to solve an optimization problem.
+To use OpenAeroStruct, you must first install OpenMDAO 3.1+ by following the instructions at https://github.com/OpenMDAO/OpenMDAO/.
+If you are unfamiliar with OpenMDAO and wish to modify the internals of OpenAeroStruct, you should examine the OpenMDAO documentation at http://openmdao.org/twodocs/versions/latest/index.html. The tutorials provided with OpenMDAO are helpful to understand the basics of using OpenMDAO to solve an optimization problem.
 
 Next, clone the OpenAeroStruct repository:
 


### PR DESCRIPTION
## Purpose
Follow-up to our discussion about matching up OpenMDAO version and OAS version well.
This OAS version is tied to OM 3.1.0 which released today.

## Type of change
- Documentation update

## Testing
All tests pass locally with OM 3.1.0.