### PR TITLE
Reducing confusion in the wingbox walkthrough example

### DIFF
--- a/openaerostruct/docs/aerostructural_wingbox_walkthrough.rst
+++ b/openaerostruct/docs/aerostructural_wingbox_walkthrough.rst
@@ -176,6 +176,7 @@ In this case, we're adding the engine mass, which is set to 10,000 kg, to an app
 The `point_mass_locations` coordinates are in the global frame.
 The loads caused by the point masses are transferred to the structural nodes based on the nodes' proximity to the point masses (using an inverse-distance approach).
 We then compute the actual `W0` value by summing the `point_masses` and `W0_without_point_masses`.
+We multiply the sum of `point_masses` by 2 because we are using symmetry.
 Thus, the `W0` value used in subsequent components includes the point masses, reserve fuel weight, and all weights of the aircraft except the wing structural mass and computed fuel burn.
 We add `point_masses` and `point_mass_locations` using `indep_var_comp` so that they can be changed during optimization (although they are not in this example).
 

--- a/openaerostruct/docs/wingbox_mpt_opt_example.py
+++ b/openaerostruct/docs/wingbox_mpt_opt_example.py
@@ -126,7 +126,7 @@ indep_var_comp.add_output('speed_of_sound', val= np.array([295.07, 340.294]), un
 
 indep_var_comp.add_output('CT', val=0.53/3600, units='1/s')
 indep_var_comp.add_output('R', val=14.307e6, units='m')
-indep_var_comp.add_output('W0_without_point_masses', val=148000 + surf_dict['Wf_reserve'] - 10.e3,  units='kg')
+indep_var_comp.add_output('W0_without_point_masses', val=128000 + surf_dict['Wf_reserve'],  units='kg')
 
 #docs checkpoint 11
 
@@ -155,7 +155,7 @@ indep_var_comp.add_output('point_mass_locations', val=point_mass_locations, unit
 
 # Compute the actual W0 to be used within OAS based on the sum of the point mass and other W0 weight
 prob.model.add_subsystem('W0_comp',
-    om.ExecComp('W0 = W0_without_point_masses + sum(point_masses)', units='kg'),
+    om.ExecComp('W0 = W0_without_point_masses + 2 * sum(point_masses)', units='kg'),
     promotes=['*'])
 
 #docs checkpoint 13
@@ -300,7 +300,7 @@ prob.model.add_constraint('fuel_diff', equals=0.)
 
 prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['optimizer'] = 'SLSQP'
-prob.driver.options['tol'] = 1e-2
+prob.driver.options['tol'] = 1e-3
 
 #docs checkpoint 26
 

--- a/openaerostruct/docs/wingbox_mpt_opt_example.py
+++ b/openaerostruct/docs/wingbox_mpt_opt_example.py
@@ -300,7 +300,7 @@ prob.model.add_constraint('fuel_diff', equals=0.)
 
 prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['optimizer'] = 'SLSQP'
-prob.driver.options['tol'] = 1e-3
+prob.driver.options['tol'] = 1e-2
 
 #docs checkpoint 26
 


### PR DESCRIPTION
## Purpose
Reducing confusion in the wingbox walkthrough example. The engine masses were being subtracted from W0 and added back in a way that caused confusion. The optimization problem remains unchanged, just some changes to the setup.

## Type of change
What types of change is it?
- Documentation update

## Testing
Ran the example locally and confirmed results do not change.

## Checklist
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added necessary documentation
