### PR TITLE
Update setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,5 @@
 omit =
     openaerostruct/utils/plot_wing.py
     openaerostruct/utils/plot_wingbox.py
-    openaerostruct/geometry/ffd_component.py
 exclude_lines =
     pragma: no cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [report]
 omit =
-    openaerostruct/utils/plot_wing.py
-    openaerostruct/utils/plot_wingbox.py
+    */openaerostruct/utils/plot_wing.py
+    */openaerostruct/utils/plot_wingbox.py
 exclude_lines =
     pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - gfortran
-    - libblas-dev
-    - liblapack-dev
-    - libopenmpi-dev
     - openmpi-bin
 
 before_install:
@@ -49,8 +46,12 @@ install:
 - pip install --user travis-sphinx;
 
 script:
+# prevent OpenMPI warning messages
+- export OMPI_MCA_btl=^openib
+# run tests
 - cd openaerostruct
 - testflo -n 2 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
+# make docs
 - cd docs;
 - travis-sphinx build --source=.;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,4 +59,4 @@ script:
 after_success:
 - travis-sphinx deploy;
 - cd ../;
-- coveralls;
+- coveralls --rcfile=../.coveragerc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - gfortran
+    - libopenmpi-dev
     - openmpi-bin
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ install:
 - pip install --user travis-sphinx;
 
 script:
-- export PYTHONPATH=$PYTHONPATH:$PWD
 - testflo -n 2 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
 - cd openaerostruct/docs;
 - travis-sphinx build --source=.;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 - pip install --upgrade pip;
 
 # install openaerostruct itself. NOTE: required packages (e.g. openmdao, numpy) are specified in setup.py.
-- pip install -e .;
+- pip install .;
 
 # install pyGeo and pySpline to run FFD tests. pyspline requires fortran compilations
 - pip install mpi4py;
@@ -46,8 +46,6 @@ install:
 - pip install coverage;
 - pip install coveralls;
 - pip install testflo;
-- export PATH=$HOME/.local/bin:$PATH;
-
 - pip install --user travis-sphinx;
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
 - cd ../..;
 
 after_success:
-- cd openaerostruct/docs;
+- cd docs;
 - travis-sphinx deploy;
 - cd ../..;
 - coveralls;

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
 - pip install --user travis-sphinx;
 
 script:
+- cd openaerostruct
 - testflo -n 2 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
 - cd openaerostruct/docs;
 - travis-sphinx build --source=.;

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,10 @@ install:
 script:
 - cd openaerostruct
 - testflo -n 2 openaerostruct --coverage --coverpkg openaerostruct --cover-omit \*tests/\* --cover-omit \*docs/\*;
-- cd openaerostruct/docs;
+- cd docs;
 - travis-sphinx build --source=.;
-- cd ../..;
 
 after_success:
-- cd docs;
 - travis-sphinx deploy;
 - cd ../..;
 - coveralls;

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,5 +58,5 @@ script:
 
 after_success:
 - travis-sphinx deploy;
-- cd ../..;
+- cd ../;
 - coveralls;

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name='openaerostruct',
     license='BSD-3',
     packages=[
         'openaerostruct',
+        'openaerostruct/docs',
         'openaerostruct/geometry',
         'openaerostruct/structures',
         'openaerostruct/aerodynamics',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='openaerostruct',
     ],
     # Test files
     package_data={
+        'openaerostruct.docs': ['*.py', '_utils/*.py'],
         'openaerostruct': ['tests/*.py', '*/tests/*.py', '*/*/tests/*.py']
     },
     # TODO: add versions?

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,16 @@ setup(name='openaerostruct',
         'openaerostruct/geometry',
         'openaerostruct/structures',
         'openaerostruct/aerodynamics',
+        'openaerostruct/transfer',
         'openaerostruct/functionals',
         'openaerostruct/integration',
         'openaerostruct/common',
         'openaerostruct/utils',
     ],
+    # Test files
+    package_data={
+        'openaerostruct': ['tests/*.py', '*/tests/*.py', '*/*/tests/*.py']
+    },
     # TODO: add versions?
     install_requires=[
         'openmdao[docs]>=3.2',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='openaerostruct',
     packages=[
         'openaerostruct',
         'openaerostruct/docs',
+        'openaerostruct/docs/_utils',
         'openaerostruct/geometry',
         'openaerostruct/structures',
         'openaerostruct/aerodynamics',
@@ -26,7 +27,6 @@ setup(name='openaerostruct',
     ],
     # Test files
     package_data={
-        'openaerostruct.docs': ['*.py', '_utils/*.py'],
         'openaerostruct': ['tests/*.py', '*/tests/*.py', '*/*/tests/*.py']
     },
     # TODO: add versions?


### PR DESCRIPTION
## Purpose
This PR was motivated by the fact that `setup.py` did not contain all the submodules within openaerostruct, notably the `transfer` module. If users did not do a developers install, then that folder would not be copied to `site-packages` and it would be missing from openaerostruct. I added it to `setup.py`, but also changed Travis to not install in-place so that errors like this can be caught in the future.

Installing the package in Travis meant I had to change several other things
- the `docs` folder had to be installed also since it's imported when the docs are built
- tests need to be copied so that they can be imported also. It's a bit ambiguous which files should be under `packages` and which files go under `package_data`, but this setup roughly mirrors what's used for OpenMDAO.
- coverage testing has to occur in the `openaerostruct` folder

I also cleaned up Travis a bit more
- removed unnecessary Ubuntu packages such as blas/lapack
- removed PYTHONPATH and PATH modifications
- added environment variable to disable warnings with OpenMPI

I am not 100% sure if the coverage counts are correct, I guess we will find out once this is merged. What's reported on coveralls do not match the output of coverage.py for some reason, but looking at past builds it's always been the case, so I think it's probably okay.


## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Maintenance
