### PR TITLE
Fixed multipoint tests

### DIFF
--- a/openaerostruct/tests/test_multipoint_aero.py
+++ b/openaerostruct/tests/test_multipoint_aero.py
@@ -1,16 +1,16 @@
-import numpy as np
 from openmdao.utils.assert_utils import assert_rel_error
 import unittest
 
 
 class Test(unittest.TestCase):
     def test(self):
+        import numpy as np
+        import openmdao.api as om
+
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry
         from openaerostruct.aerodynamics.aero_groups import AeroPoint
         from openaerostruct.integration.multipoint_comps import MultiCD
-
-        import openmdao.api as om
 
         # Create a dictionary to store options about the surface
         mesh_dict = {

--- a/openaerostruct/tests/test_multipoint_aero.py
+++ b/openaerostruct/tests/test_multipoint_aero.py
@@ -7,7 +7,6 @@ class Test(unittest.TestCase):
     def test(self):
         from openaerostruct.geometry.utils import generate_mesh
         from openaerostruct.geometry.geometry_group import Geometry
-
         from openaerostruct.aerodynamics.aero_groups import AeroPoint
         from openaerostruct.integration.multipoint_comps import MultiCD
 
@@ -70,20 +69,17 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem('prob_vars', indep_var_comp, promotes=['*'])
 
-        # Loop over each surface in the surfaces list
+        # Loop over each surface and create the geometry groups
         for surface in surfaces:
-            # Get the surface name and create a group to contain components
-            # only for this surface
+            # Get the surface name and create a group to contain components only for this surface.
             name = surface['name']
-
             geom_group = Geometry(surface=surface)
 
-            # Add tmp_group to the problem with the name of the surface.
+            # Add geom_group to the problem with the name of the surface.
             prob.model.add_subsystem(name + '_geom', geom_group)
 
         # Loop through and add a certain number of aero points
         for i in range(n_points):
-
             # Create the aero point group and add it to the model
             aero_group = AeroPoint(surfaces=surfaces)
             point_name = 'aero_point_{}'.format(i)
@@ -101,14 +97,13 @@ class Test(unittest.TestCase):
             for surface in surfaces:
                 name = surface['name']
 
-                # Connect the drag coeff at this point to the multi_CD component, which does the summation.
+                # Connect the drag coeff at each point to the multi_CD component, which does the summation.
                 prob.model.connect(point_name + '.CD', 'multi_CD.' + str(i) + '_CD')
 
                 # Connect the mesh from the geometry component to the analysis point
                 prob.model.connect(name + '_geom.mesh', point_name + '.' + name + '.def_mesh')
 
-                # Perform the connections with the modified names within the
-                # 'aero_states' group.
+                # Perform the connections with the modified names within the 'aero_states' group.
                 prob.model.connect(name + '_geom.mesh', point_name + '.aero_states.' + name + '_def_mesh')
                 prob.model.connect(name + '_geom.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
@@ -118,7 +113,7 @@ class Test(unittest.TestCase):
         prob.driver.options['tol'] = 1e-9
 
         # Setup problem and add design variables, constraint, and objective
-        # design variable is the wing twist, and angle-of-attack at each point.
+        # design variables are the wing twist and angle-of-attack at each point.
         prob.model.add_design_var('alpha', lower=-15, upper=15)
         prob.model.add_design_var('wing_geom.twist_cp', lower=-5, upper=8)
 
@@ -129,7 +124,7 @@ class Test(unittest.TestCase):
         # objective is the sum of CDs at each point.
         prob.model.add_objective('CD', scaler=1e4)
 
-        # Set up the problem and run optimization
+        # Set up the problem and run optimization.
         prob.setup()
         prob.run_driver()
 

--- a/openaerostruct/tests/test_multipoint_aero_ffd.py
+++ b/openaerostruct/tests/test_multipoint_aero_ffd.py
@@ -81,6 +81,20 @@ class Test(unittest.TestCase):
 
         prob.model.add_subsystem('prob_vars', indep_var_comp, promotes=['*'])
 
+        # Loop over each surface in the surfaces list
+        for surface in surfaces:
+            # Get the surface name and create a group to contain components
+            # only for this surface
+            name = surface['name']
+
+            # FFD setup
+            filename = write_FFD_file(surface, surface['mx'], surface['my'])
+            DVGeo = DVGeometry(filename)
+            geom_group = Geometry(surface=surface, DVGeo=DVGeo)
+
+            # Add tmp_group to the problem with the name of the surface.
+            prob.model.add_subsystem(name + '_geom', geom_group)
+
         # Loop through and add a certain number of aero points
         for i in range(n_points):
 
@@ -99,50 +113,37 @@ class Test(unittest.TestCase):
 
             # Connect the parameters within the model for each aero point
             for surface in surfaces:
-
-                filename = write_FFD_file(surface, surface['mx'], surface['my'])
-                DVGeo = DVGeometry(filename)
-                geom_group = Geometry(surface=surface, DVGeo=DVGeo)
-
-                # Add tmp_group to the problem as the name of the surface.
-                # Note that is a group and performance group for each
-                # individual surface.
-                aero_group.add_subsystem(surface['name'] + '_geom', geom_group)
-
                 name = surface['name']
+
+                # Connect the drag coeff at this point to the multi_CD component, which does the summation.
                 prob.model.connect(point_name + '.CD', 'multi_CD.' + str(i) + '_CD')
 
                 # Connect the mesh from the geometry component to the analysis point
-                prob.model.connect(point_name + '.' + name + '_geom.mesh', point_name + '.' + name + '.def_mesh')
+                prob.model.connect(name + '_geom.mesh', point_name + '.' + name + '.def_mesh')
 
                 # Perform the connections with the modified names within the
                 # 'aero_states' group.
-                prob.model.connect(
-                    point_name + '.' + name + '_geom.mesh', point_name + '.aero_states.' + name + '_def_mesh'
-                )
-
-                prob.model.connect(
-                    point_name + '.' + name + '_geom.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c'
-                )
+                prob.model.connect(name + '_geom.mesh', point_name + '.aero_states.' + name + '_def_mesh')
+                prob.model.connect(name + '_geom.t_over_c', point_name + '.' + name + '_perf.' + 't_over_c')
 
         prob.model.add_subsystem('multi_CD', MultiCD(n_points=n_points), promotes_outputs=['CD'])
 
         prob.driver = om.ScipyOptimizeDriver()
 
-        # # Setup problem and add design variables, constraint, and objective
+        # Setup problem and add design variables, constraint, and objective
+        # design variable is the wing shape, and angle-of-attack at each point.
         prob.model.add_design_var('alpha', lower=-15, upper=15)
+        prob.model.add_design_var('wing_geom.shape', lower=-3, upper=2)
 
-        prob.model.add_design_var('aero_point_0.wing_geom.shape', lower=-3, upper=2)
+        # set different target CL value at each point.
         prob.model.add_constraint('aero_point_0.wing_perf.CL', equals=0.45)
-
-        prob.model.add_design_var('aero_point_1.wing_geom.shape', lower=-3, upper=2)
         prob.model.add_constraint('aero_point_1.wing_perf.CL', equals=0.5)
 
+        # objective is the sum of CDs at each point.
         prob.model.add_objective('CD', scaler=1e4)
 
         # Set up the problem
         prob.setup()
-
         prob.run_model()
 
         # Check the partials at this point in the design space


### PR DESCRIPTION
## Purpose
Some multipoint tests (which also appear in the docs) were not actually multipoint, but they were multi-aircraft/ morphing. This is because the geometry groups were added under each aero points repeatedly and individually, although the geometry should be consistent between all aero points.

This PR fixes #284, by removing the geometry groups from each aero point, adding them outside the aero point groups, and connecting the single geometry to each aero point.  
I also needed to update the reference values in `test_multipoint_aero.py`, because the optimization problem it solves is changed.

## Type of change
- Bugfix (non-breaking change which fixes an issue)
- Code style update (formatting, renaming)

## Checklist
- [ x ] I have run unit and regression tests which pass locally with my changes