### PR TITLE
Promote beta (sideslip angle) to the top of AerostructGroup

### DIFF
--- a/openaerostruct/integration/aerostruct_groups.py
+++ b/openaerostruct/integration/aerostruct_groups.py
@@ -127,7 +127,7 @@ class CoupledPerformance(om.Group):
 
         self.add_subsystem('aero_funcs',
             VLMFunctionals(surface=surface),
-            promotes_inputs=['v', 'alpha', 'Mach_number', 're', 'rho', 'widths', 'cos_sweep', 'lengths', 'S_ref', 'sec_forces', 't_over_c'], promotes_outputs=['CDv', 'L', 'D', 'CL1', 'CDi', 'CD', 'CL'])
+            promotes_inputs=['v', 'alpha', 'beta', 'Mach_number', 're', 'rho', 'widths', 'cos_sweep', 'lengths', 'S_ref', 'sec_forces', 't_over_c'], promotes_outputs=['CDv', 'L', 'D', 'CL1', 'CDi', 'CD', 'CL'])
 
         if surface['fem_model_type'] == 'tube':
             self.add_subsystem('struct_funcs',
@@ -260,7 +260,7 @@ class AerostructPoint(om.Group):
         """
         ### End change of solver settings ###
         """
-        prom_in = ['v', 'alpha', 'rho']
+        prom_in = ['v', 'alpha', 'beta', 'rho']
         if self.options['compressible'] == True:
             prom_in.append('Mach_number')
 
@@ -274,7 +274,7 @@ class AerostructPoint(om.Group):
             # the coupled system
             perf_group = CoupledPerformance(surface=surface)
 
-            self.add_subsystem(name + '_perf', perf_group, promotes_inputs=['rho', 'v', 'alpha', 're', 'Mach_number'])
+            self.add_subsystem(name + '_perf', perf_group, promotes_inputs=['rho', 'v', 'alpha', 'beta', 're', 'Mach_number'])
 
         # Add functionals to evaluate performance of the system.
         # Note that only the interesting results are promoted here; not all

--- a/openaerostruct/tests/test_aerostruct.py
+++ b/openaerostruct/tests/test_aerostruct.py
@@ -142,6 +142,10 @@ class Test(unittest.TestCase):
         # Set up the problem
         prob.setup(check=True)
 
+        # Inserting a small unit test here. Verify that beta is correctly promoted in an Aerostruct
+        # group.
+        assert_rel_error(self, prob['AS_point_0.beta'], 0.0)
+
         prob.run_driver()
 
         assert_rel_error(self, prob['AS_point_0.fuelburn'][0], 97696.33252514644, 1e-8)

--- a/openaerostruct/tests/test_aerostruct_analysis_compressible.py
+++ b/openaerostruct/tests/test_aerostruct_analysis_compressible.py
@@ -76,6 +76,7 @@ class Test(unittest.TestCase):
         indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('v', val=248.136, units='m/s')
         indep_var_comp.add_output('alpha', val=5., units='deg')
+        indep_var_comp.add_output('beta', val=0., units='deg')
         indep_var_comp.add_output('Mach_number', val=0.84)
         indep_var_comp.add_output('re', val=1.e6, units='1/m')
         indep_var_comp.add_output('rho', val=0.38, units='kg/m**3')
@@ -116,6 +117,7 @@ class Test(unittest.TestCase):
             # Connect flow properties to the analysis point
             prob.model.connect('v', point_name + '.v')
             prob.model.connect('alpha', point_name + '.alpha')
+            prob.model.connect('beta', point_name + '.beta')
             prob.model.connect('Mach_number', point_name + '.Mach_number')
             prob.model.connect('re', point_name + '.re')
             prob.model.connect('rho', point_name + '.rho')


### PR DESCRIPTION
## Purpose
I was running a case where I needed to compute the derivative of an OpenAerostruct model with respect to beta, and found that it wasn't promoted. It was actually partially promoted in a couple of spots, but some important ones were missing.

## Type of change
What types of change is it?

- Bugfix (non-breaking change which fixes an issue)
closes #342

- Breaking change (non-backwards-compatible fix or feature)
Not a major "breaking" change, but since version 3.2 of OpenMDAO, auto-indepvarcomps are automatically created for unconnected inputs. To prevent ambiguity, if inputs with different units are promoted together, OpenMDAO raises an error. You can work around this by adding that input to your top level indepvarcomp, but a more correct way is to use `group.set_input_defaults` to define the source units (but use of this will tie you to OpenMDAO 3.2 or greater.)

See test_aerostruct_analysis_compressible.py.  This will only occur when using the compressible aerodynamic analysis, as the transformation to the wind-frame declares the input beta in radians instead of degrees.

Note also that if the user omits some of the other variables from the indpevarcomp at the top of the model (for example, alpha), they also get this same error. You may want to consider making the mods to OAS to work with the latest OpenMDAO, but that is a separate issue.

## Testing
Quick test added to an existing test.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [NA] I have added necessary documentation
