### PR TITLE
Readme update for OM versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Shamsheer S. Chauhan and Joaquim R. R. A. Martins, “Low-Fidelity Aerostructura
 
 Version Information
 -------------------
-This version of OpenAeroStruct requires [OpenMDAO](https://github.com/OpenMDAO/openmdao) 3.2+ and Python3.
+This version of OpenAeroStruct requires [OpenMDAO](https://github.com/OpenMDAO/openmdao) (versions 3.2.0 to 3.6.0) and Python3.
 Python2 is no longer supported.
 It also requires the folloing packages: `numpy, scipy, matplotlib`.
 If you are looking to use the previous version of OpenAeroStruct which uses OpenMDAO 1.7.4, use OpenAeroStruct 1.0 from [here](https://github.com/mdolab/OpenAeroStruct/releases).


### PR DESCRIPTION
## Purpose
To avoid having to update OAS every time OM changes, this makes the readme and docs more restrictive about the required versions.

## Type of change
- Documentation update
