### PR TITLE
Fix plot_wingbox.py to work for matplotlib v3.8+

### DIFF
--- a/openaerostruct/utils/plot_wingbox.py
+++ b/openaerostruct/utils/plot_wingbox.py
@@ -1,7 +1,10 @@
 """
-
+This is a custom script for visualizing the optimization results when using the wingbox structural model.
 This only works when using the wingbox model with MULTIPOINT analysis/optimization.
+Modifications will be necessary when moving away from the intended optimization problem formulation,
+and this can be used as a starting point.
 
+The usage, for example, if running a case from the `examples` directory would be `python ../utils/plot_wingbox.py aerostruct.db`.
 """
 
 
@@ -588,14 +591,6 @@ class Display(object):
     def plot_wing(self):
         n_names = len(self.names)
         self.ax.cla()
-        az = self.ax.azim
-        el = self.ax.elev
-        dist = self.ax.dist
-
-        # for a planform view use:
-        # az = 270
-        # el = 0.
-        # dist = 15.
 
         for j, name in enumerate(self.names):
             # for wingbox viz
@@ -760,8 +755,7 @@ class Display(object):
                 color="k",
             )
 
-        self.ax.view_init(elev=el, azim=az)  # Reproduce view
-        self.ax.dist = dist
+        self.ax.view_init()  # Reproduce view
 
     def save_video(self):
         options = dict(title="Movie", artist="Matplotlib")


### PR DESCRIPTION
## Purpose
Fix plot_wingbox.py to work for matplotlib v3.8+.
The `dist` attribute for 3-D plots has been deprecated in recent matplotlib versions.
See Issue #423 

## Expected time until merged
1 day
Code review should only take a few minutes.

## Type of change
 Bugfix (non-breaking change which fixes an issue)

## Testing
Run the wingbox example in the examples dir (can reduce  "num_y" to 15 and "num_x" to 3 to decrease run time) and call the plot_wingbox script (usage: `python ../utils/plot_wingbox.py aerostruct.db`).
Tested with matplotlib versions:
* 3.6.0
* 3.7.0
* 3.8.0
* 3.8.3

![image](https://github.com/mdolab/OpenAeroStruct/assets/14077857/e6c88d7f-455d-4729-b70f-3f3e7319f067)


## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
