### PR TITLE
Fix plot_wing.py to work for matplotlib v3.8+

### DIFF
--- a/openaerostruct/utils/plot_wing.py
+++ b/openaerostruct/utils/plot_wing.py
@@ -465,7 +465,6 @@ class Display(object):
         self.ax.cla()
         az = self.ax.azim
         el = self.ax.elev
-        dist = self.ax.dist
 
         for j, name in enumerate(self.names):
             mesh0 = self.mesh[self.curr_pos * n_names + j].copy()
@@ -577,7 +576,6 @@ class Display(object):
             self.ax.text2D(0.15, 0.05, self.obj_key + ": {}".format(obj_val), transform=self.ax.transAxes, color="k")
 
         self.ax.view_init(elev=el, azim=az)  # Reproduce view
-        self.ax.dist = dist
 
     def save_video(self):
         options = dict(title="Movie", artist="Matplotlib")

--- a/openaerostruct/utils/plot_wingbox.py
+++ b/openaerostruct/utils/plot_wingbox.py
@@ -591,6 +591,8 @@ class Display(object):
     def plot_wing(self):
         n_names = len(self.names)
         self.ax.cla()
+        az = self.ax.azim
+        el = self.ax.elev
 
         for j, name in enumerate(self.names):
             # for wingbox viz
@@ -755,7 +757,7 @@ class Display(object):
                 color="k",
             )
 
-        self.ax.view_init()  # Reproduce view
+        self.ax.view_init(elev=el, azim=az)  # Reproduce view
 
     def save_video(self):
         options = dict(title="Movie", artist="Matplotlib")


### PR DESCRIPTION
## Purpose
Fix plot_wing.py to work for matplotlib v3.8+.
The `dist` attribute for 3-D plots has been deprecated in recent matplotlib versions.
See related Issue #423

Also made the 3-D view behavior consistent in plot_wingbox.py (the 3-D view should not reset if the iteration is changed).

## Expected time until merged
1 day
Code review should only take a few minutes.

## Type of change
 Bugfix (non-breaking change which fixes an issue)

## Testing
Ran the run_CRM.py and run_aerostruct_uCRM_multipoint.py examples, and also confirmed that the views don't reset it the iteration is changed.
Tested with matplotlib versions:
* 3.6.0
* 3.7.0
* 3.8.0
* 3.8.3

![image](https://github.com/mdolab/OpenAeroStruct/assets/14077857/a5b677c2-6e37-4e1a-8d36-c57fde24ecbf)

![image](https://github.com/mdolab/OpenAeroStruct/assets/14077857/2fe08db0-8dc3-4803-b304-bf50a4281ffe)


## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
