### PR TITLE
Adding option to prevent OpenMDAO from suppressing tecplot file writing

### DIFF
--- a/openaerostruct/mphys/lift_distribution.py
+++ b/openaerostruct/mphys/lift_distribution.py
@@ -42,6 +42,8 @@ class LiftDistribution(ExplicitComponent):
             nx, ny, _ = mesh.shape
             self.add_input(name + "_def_mesh", val=mesh, units="m", tags=["mphys_coupling"])
             self.add_input(name + "_sec_forces", val=np.ones((nx - 1, ny - 1, 3)), units="N", tags=["mphys_coupling"])
+        # Prevents OpenMDAO from suppressing this component when using group_by_pre_opt_post feature
+        self.options['always_opt'] = True
 
     def compute(self, inputs, outputs):
         """

--- a/openaerostruct/mphys/surface_contours.py
+++ b/openaerostruct/mphys/surface_contours.py
@@ -47,6 +47,8 @@ class SurfaceContour(ExplicitComponent):
             self.add_input(name + "_sec_forces", val=np.ones([nx - 1, ny - 1, 3]), units="N", tags=["mphys_coupling"])
         self.add_input("circulations", val=np.zeros([tot_panels]), units="m**2/s", tags=["mphys_coupling"])
         self.solution_counter = 0
+        # Prevents OpenMDAO from suppressing this component when using group_by_pre_opt_post feature
+        self.options['always_opt'] = True
 
     def compute(self, inputs, outputs):
         """


### PR DESCRIPTION
## Purpose
Prevents OpenMDAO from suppressing MPhys postprocessing components when using [`group_by_pre_opt_post`](https://openmdao.org/newdocs/versions/latest/features/experimental/pre_opt_post.html?highlight=group_by_pre#moving-some-systems-outside-of-the-optimization-loop) feature.
## Expected time until merged
a week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
